### PR TITLE
Bugfix

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -70,7 +70,8 @@
     ((equal end-of-line "lf") 'undecided-unix)
     ((equal end-of-line "cr") 'undecided-mac)
     ((equal end-of-line "crlf") 'undecided-dos)
-    (t 'undecided))))
+    (t 'undecided))
+   nil t))
 
 (defun edconf-set-trailing-nl (final-newline)
   (cond


### PR DESCRIPTION
Hi,

These commits fix 3 issues:
- Do not raise an error if the program `editorconfig` is not found.
- Set default value of file coding system.
- Do not mark the buffer modified after setting the file coding system.

Please merge them.

Thanks
