### PR TITLE
Autoload edconf-find-file-hook.

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -137,6 +137,7 @@
                 (val (mapconcat 'identity (cdr key-val) "")))
             (puthash key val properties)))))))
 
+;;;###autoload
 (defun edconf-find-file-hook ()
   (when (executable-find edconf-exec-path)
     (let ((props (edconf-parse-properties (edconf-get-properties))))


### PR DESCRIPTION
Or you'll get `Symbol's function definition is void: edconf-find-file-hook` when `find-file-hook` is run.
