### PR TITLE
Bump Version

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2011-2013 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
-;; Version: 0.2
+;; Version: 0.3
 ;; URL: http://github.com/editorconfig/editorconfig-emacs#readme
 
 ;; See
@@ -12,7 +12,7 @@
 
 ;; Redistribution and use in source and binary forms, with or without
 ;; modification, are permitted provided that the following conditions are met:
-;; 
+;;
 ;; 1. Redistributions of source code must retain the above copyright notice,
 ;;    this list of conditions and the following disclaimer.
 ;; 2. Redistributions in binary form must reproduce the above copyright notice,


### PR DESCRIPTION
increment version to 0.3 and remove a trailing whitespace

The version of editorconfig-emacs on marmalade-repo.org is 0.2, but it is out of date (lacks haskell, js2-mode support).

A new version should be pushed to marmalade-repo.org after the version number is updated; it may be necessary to get the credentials to do that from @xuhdev (http://marmalade-repo.org/packages/editorconfig)
