### PR TITLE
Added missing padding options for web-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -81,7 +81,9 @@
     (web-mode (web-mode-indent-style . (lambda (size) 2))
               web-mode-markup-indent-offset
               web-mode-css-indent-offset
-              web-mode-code-indent-offset))
+              web-mode-code-indent-offset
+              web-mode-script-padding
+              web-mode-style-padding))
   "Alist of indentation setting methods by modes.
 
 Each element looks like (MODE . FUNCTION) or (MODE . INDENT-SPEC-LIST).


### PR DESCRIPTION
These options define how much the code inside `<script>` and `<style>` tags should be indented, respectively. Without setting these, the first level of code inside those tags will aligned flush with the tags themselves.
