### PR TITLE
Make regex for .editorconfig file name detection more accurate

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -291,7 +291,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
 ;;;###autoload
 (add-hook 'find-file-hook 'edconf-find-file-hook)
 
-(add-to-list 'auto-mode-alist '("\\.editorconfig" . conf-unix-mode))
+(add-to-list 'auto-mode-alist '("/\\.editorconfig$" . conf-unix-mode))
 
 (provide 'editorconfig)
 


### PR DESCRIPTION
As @johan has pointed out in my previous commit, the regex to enable syntax highlighting in .editorconfig files was not specific enough. This minor change ensures that only .editorconfig files are selected and avoid any odd anomalies.