### PR TITLE
Use message log to report about unavailabe editorconfig file

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -289,7 +289,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
       (edconf-set-line-length (gethash 'max_line_length props))
       (dolist (hook edconf-custom-hooks)
         (funcall hook props)))
-    (display-warning :error "Unable to find editorconfig executable.  Styles will not be applied.")))
+    (message "Unable to find editorconfig executable.  Styles will not be applied.")))
 ;;;###autoload
 (add-hook 'find-file-hook 'edconf-find-file-hook)
 


### PR DESCRIPTION
Hello everyone,

May I propose something? Could we please use the Message Log for reporting about missing editorconfig file instead of that `display-warning`?

I mean, `display-warning` shouts about it right in your face (creating a new window in the current layout) which is not convenient in some situations.

Thanks.