### PR TITLE
Make EditorConfig core function pluggable

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -286,20 +286,30 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
                 (val (mapconcat 'identity (cdr key-val) "")))
             (puthash key val properties)))))))
 
+(defun edconf-get-properties-from-exec ()
+  "Get EditorConfig properties of current buffer by calling `edconf-exec-path'."
+  (if (executable-find edconf-exec-path)
+    (edconf-parse-properties (edconf-get-properties))
+    (display-warning :error
+      "Unable to find editorconfig executable.")
+    nil))
+
 ;;;###autoload
 (defun edconf-find-file-hook ()
-  (if (executable-find edconf-exec-path)
-    (let ((props (edconf-parse-properties (edconf-get-properties))))
-      (edconf-set-indentation (gethash 'indent_style props)
-                              (gethash 'indent_size props)
-                              (gethash 'tab_width props))
-      (edconf-set-line-ending (gethash 'end_of_line props))
-      (edconf-set-trailing-nl (gethash 'insert_final_newline props))
-      (edconf-set-trailing-ws (gethash 'trim_trailing_whitespace props))
-      (edconf-set-line-length (gethash 'max_line_length props))
-      (dolist (hook edconf-custom-hooks)
-        (funcall hook props)))
-    (display-warning :error "Unable to find editorconfig executable.  Styles will not be applied.")))
+  (let ((props (and (functionp edconf-get-properties-function)
+                 (funcall edconf-get-properties-function))))
+    (if props
+      (progn
+        (edconf-set-indentation (gethash 'indent_style props)
+          (gethash 'indent_size props)
+          (gethash 'tab_width props))
+        (edconf-set-line-ending (gethash 'end_of_line props))
+        (edconf-set-trailing-nl (gethash 'insert_final_newline props))
+        (edconf-set-trailing-ws (gethash 'trim_trailing_whitespace props))
+        (edconf-set-line-length (gethash 'max_line_length props))
+        (dolist (hook edconf-custom-hooks)
+          (funcall hook props)))
+      (display-warning :error "EditorConfig core program is not available.  Styles will not be applied."))))
 ;;;###autoload
 (add-hook 'find-file-hook 'edconf-find-file-hook)
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -47,7 +47,7 @@
 (defcustom edconf-get-properties-function
   'edconf-get-properties-from-exec
   "Function to get EditorConofig properties for current buffer.
-This function willl be called with no argument and should return a hash object
+This function will be called with no argument and should return a hash object
 containing properties, or nil if any core program is not available.
 The hash object should have symbols of property names as keys and strings of
 property values as values."

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -44,6 +44,16 @@
   :type 'string
   :group 'editorconfig)
 
+(defcustom edconf-get-properties-function
+  'edconf-get-properties-from-exec
+  "Function to get EditorConofig properties for current buffer.
+This function willl be called with no argument and should return a hash object
+containing properties, or nil if any core program is not available.
+The hash object should have symbols of property names as keys and strings of
+property values as values."
+  :type 'function
+  :group 'editorconfig)
+
 (defcustom edconf-custom-hooks ()
   "A list of custom hooks after loading common EditorConfig settings
 


### PR DESCRIPTION
This PR adds a variable `edconf-get-properties-function` so that users can change the function to use to get EditorConfig properties.

For example, `editorconfig-core-get-properties-hash`, which I implemented in [`editorconfig-core-emacslisp`](https://github.com/10sr/editorconfig-core-emacslisp) library, can be set to the value of this variable.
This enables users to get properties without installing any external command-line tools like `editorconfig-core-c`.

The original implementation using `edconf-exec-path` is defined as a function `edconf-get-properties-from-exec`, and this function is set to the default value of this variable.
So this PR does not change the default behavior.
