### PR TITLE
Apply settings on major mode change

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -331,11 +331,12 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   "Toggle EditorConfig feature."
   :global t
   :lighter ""
-  (if editorconfig-mode
-    (add-hook 'find-file-hook
-      'editorconfig-apply)
-    (remove-hook 'find-file-hook
-      'editorconfig-apply)))
+  (dolist (hook (list
+                  'find-file-hook
+                  'after-change-major-mode-hook))
+    (if editorconfig-mode
+      (add-hook hook 'editorconfig-apply)
+      (remove-hook hook 'editorconfig-apply))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("/\\.editorconfig\\'" . conf-unix-mode))


### PR DESCRIPTION
Emacs reacts strangely if `after-change-major-mode-hook` is there: even `M-x` won't work. Removing `after-change-major-mode-hook` would solve the problem (which is removing line 336 in the new version). What is the problem with it?