### PR TITLE
Don't error out if default-directory doesn't exist.

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -281,14 +281,11 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
 
 (defun editorconfig-get-properties ()
   "Call EditorConfig core and return output"
-  (let ((oldbuf (current-buffer)))
-    (call-process editorconfig-exec-path nil "ecbuffer" nil (buffer-file-name oldbuf))
-    (set-buffer (get-buffer "ecbuffer"))
-    (let (props-string)
-      (setq props-string (buffer-string))
-      (set-buffer oldbuf)
-      (kill-buffer (get-buffer "ecbuffer"))
-      props-string)))
+  (let ((filename (buffer-file-name)))
+    (with-temp-buffer
+      (setq default-directory "/")
+      (call-process editorconfig-exec-path nil t nil filename)
+      (buffer-string))))
 
 (defun editorconfig-parse-properties (props-string)
   "Create properties hash table from string of properties"


### PR DESCRIPTION
Changed editorconfig-get-properties to set default-directory to "/"
before calling create-process.  Create-process tries to set the current
directory from default-directory and will error out if this directory
doesn't exist.  This was causing editorconfig-get-properties to fail
when visiting a file in a directory that doesn't exist (yet).

Also use with-temp-buffer to create and manage the temporary buffer used
by editorconfig-get-properties instead of duplicating that functionaily
by hand.

Fixes #35 