### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ in to all different packages for whitespace trimming to inform
 them about editorconfig settings, but aim for better coverage
 of things like [ws-trim](ftp://ftp.lysator.liu.se/pub/emacs/ws-trim.el).
 
+## Testing
+
+Make and [CMake](https://cmake.org) must be installed to run the tests.
+
+To run the tests:
+
+    $ make test
+
 ## Submitting Bugs and Feature Requests
 
 Bugs, feature requests, and other issues should be submitted to the issue

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -32,22 +32,16 @@
 ;; .editorconfig files and returns properties for given files.
 ;; This can be used in place of, for example, editorconfig-core-c.
 
-;; This library is not an editor plugin and does not configure Emacs for editing
-;; the files: this should be done with editorconfig-emacs.
-
 
 ;; Use from EditorConfig Emacs Plugin
 
-;; editorconfig-emacs (v0.5 or later) can utilize this library.
-;; Add following lines to your init.el:
+;; Emacs plugin (v0.5 or later) can utilize this implementation.
+;; By default, the plugin first search for any EditorConfig executable,
+;; and fallback to this library if not found.
+;; If you always want to use this library, add following lines to your init.el:
 
 ;;     (setq editorconfig-get-properties-function
 ;;           'editorconfig-core-get-properties-hash)
-
-;; This sexp configures editorconfig-emacs to call this library when getting
-;; EditorConfig properties instead of the default function
-;; editorconfig-get-properties-from-exec, which invokes external program
-;; like editorconfig-core-c.
 
 
 ;; Functions

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -328,6 +328,7 @@ It calls `editorconfig-get-properties-from-exec' if
 ;;;###autoload
 (defun editorconfig-apply ()
   "Apply EditorConfig properties for current buffer."
+  (interactive)
   (when buffer-file-name
     (let ((props (and (functionp editorconfig-get-properties-function)
                    (funcall editorconfig-get-properties-function))))

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -94,45 +94,45 @@ property emacs_linum to decide whether to show line numbers on the left
 
 (defcustom editorconfig-indentation-alist
   '((awk-mode c-basic-offset)
-    (c++-mode c-basic-offset)
-    (c-mode c-basic-offset)
-    (cmake-mode cmake-tab-width)
-    (coffee-mode coffee-tab-width)
-    (cperl-mode cperl-indent-level)
-    (css-mode css-indent-offset)
-    (emacs-lisp-mode lisp-indent-offset)
-    (erlang-mode erlang-indent-level)
-    (groovy-mode c-basic-offset)
-    (haskell-mode haskell-indent-spaces
-                  haskell-indent-offset
-                  shm-indent-spaces)
-    (idl-mode c-basic-offset)
-    (java-mode c-basic-offset)
-    (js-mode js-indent-level)
-    (js2-mode js2-basic-offset)
-    (js3-mode js3-indent-level)
-    (json-mode js-indent-level)
-    (latex-mode . editorconfig-set-indentation/latex-mode)
-    (lisp-mode lisp-indent-offset)
-    (livescript-mode livescript-tab-width)
-    (mustache-mode mustache-basic-offset)
-    (nxml-mode nxml-child-indent (nxml-attribute-indent . 2))
-    (objc-mode c-basic-offset)
-    (perl-mode perl-indent-level)
-    (pike-mode c-basic-offset)
-    (puppet-mode puppet-indent-level)
-    (python-mode . editorconfig-set-indentation/python-mode)
-    (ruby-mode ruby-indent-level)
-    (scala-mode scala-indent:step)
-    (sgml-mode sgml-basic-offset)
-    (sh-mode sh-basic-offset sh-indentation)
-    (web-mode (web-mode-indent-style . (lambda (size) 2))
-              web-mode-markup-indent-offset
-              web-mode-css-indent-offset
-              web-mode-code-indent-offset
-              web-mode-script-padding
-              web-mode-style-padding)
-    (yaml-mode yaml-indent-offset))
+     (c++-mode c-basic-offset)
+     (c-mode c-basic-offset)
+     (cmake-mode cmake-tab-width)
+     (coffee-mode coffee-tab-width)
+     (cperl-mode cperl-indent-level)
+     (css-mode css-indent-offset)
+     (emacs-lisp-mode lisp-indent-offset)
+     (erlang-mode erlang-indent-level)
+     (groovy-mode c-basic-offset)
+     (haskell-mode haskell-indent-spaces
+       haskell-indent-offset
+       shm-indent-spaces)
+     (idl-mode c-basic-offset)
+     (java-mode c-basic-offset)
+     (js-mode js-indent-level)
+     (js2-mode js2-basic-offset)
+     (js3-mode js3-indent-level)
+     (json-mode js-indent-level)
+     (latex-mode . editorconfig-set-indentation/latex-mode)
+     (lisp-mode lisp-indent-offset)
+     (livescript-mode livescript-tab-width)
+     (mustache-mode mustache-basic-offset)
+     (nxml-mode nxml-child-indent (nxml-attribute-indent . 2))
+     (objc-mode c-basic-offset)
+     (perl-mode perl-indent-level)
+     (pike-mode c-basic-offset)
+     (puppet-mode puppet-indent-level)
+     (python-mode . editorconfig-set-indentation/python-mode)
+     (ruby-mode ruby-indent-level)
+     (scala-mode scala-indent:step)
+     (sgml-mode sgml-basic-offset)
+     (sh-mode sh-basic-offset sh-indentation)
+     (web-mode (web-mode-indent-style . (lambda (size) 2))
+       web-mode-markup-indent-offset
+       web-mode-css-indent-offset
+       web-mode-code-indent-offset
+       web-mode-script-padding
+       web-mode-style-padding)
+     (yaml-mode yaml-indent-offset))
   "Alist of indentation setting methods by modes.
 
 Each element looks like (MODE . FUNCTION) or (MODE . INDENT-SPEC-LIST).
@@ -181,11 +181,11 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
 (defun editorconfig-set-indentation/python-mode (size)
   "Set `python-mode' indent size to SIZE."
   (set (make-local-variable (if (or (> emacs-major-version 24)
-                                    (and (= emacs-major-version 24)
-                                         (>= emacs-minor-version 3)))
-                                'python-indent-offset
+                                  (and (= emacs-major-version 24)
+                                    (>= emacs-minor-version 3)))
+                              'python-indent-offset
                               'python-indent))
-       size)
+    size)
   ;; For https://launchpad.net/python-mode
   (when (boundp 'py-indent-offset)
     (set (make-local-variable 'py-indent-offset) size)))
@@ -211,58 +211,58 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
     (setq size (string-to-number size))
     (when (not (equal size "tab")) (setq size nil)))
   (setq tab-width (cond (tab_width (string-to-number tab_width))
-                        ((numberp size) size)
-                        (t tab-width)))
+                    ((numberp size) size)
+                    (t tab-width)))
   (when (equal size "tab")
     (setq size tab-width))
   (cond ((equal style "space")
-         (setq indent-tabs-mode nil))
-        ((equal style "tab")
-         (setq indent-tabs-mode t)))
+          (setq indent-tabs-mode nil))
+    ((equal style "tab")
+      (setq indent-tabs-mode t)))
   (when size
     (when (featurep 'evil)
       (set (make-local-variable 'evil-shift-width) size))
     (let ((parent major-mode)
-          entry)
+           entry)
       ;; Find the closet parent mode of `major-mode' in
       ;; `editorconfig-indentation-alist'.
       (while (and (not (setq entry (assoc parent editorconfig-indentation-alist)))
-                  (setq parent (get parent 'derived-mode-parent))))
+               (setq parent (get parent 'derived-mode-parent))))
       (when entry
         (let ((fn-or-list (cdr entry)))
           (cond ((functionp fn-or-list) (funcall fn-or-list size))
-                ((listp fn-or-list)
-                 (dolist (elem fn-or-list)
-                   (cond ((symbolp elem) (set (make-local-variable elem) size))
-                         ((consp elem)
-                          (let ((spec (cdr elem)))
-                            (set (make-local-variable (car elem))
-                                 (cond ((functionp spec) (funcall spec size))
-                                       ((integerp spec) (* spec size))
-                                       (t spec))))))))))))))
+            ((listp fn-or-list)
+              (dolist (elem fn-or-list)
+                (cond ((symbolp elem) (set (make-local-variable elem) size))
+                  ((consp elem)
+                    (let ((spec (cdr elem)))
+                      (set (make-local-variable (car elem))
+                        (cond ((functionp spec) (funcall spec size))
+                          ((integerp spec) (* spec size))
+                          (t spec))))))))))))))
 
 (defun editorconfig-set-line-ending (end-of-line)
   "Set line ending style to CR, LF, or CRLF by END-OF-LINE."
   (set-buffer-file-coding-system
-   (cond
-    ((equal end-of-line "lf") 'undecided-unix)
-    ((equal end-of-line "cr") 'undecided-mac)
-    ((equal end-of-line "crlf") 'undecided-dos)
-    (t 'undecided))
-   nil t))
+    (cond
+      ((equal end-of-line "lf") 'undecided-unix)
+      ((equal end-of-line "cr") 'undecided-mac)
+      ((equal end-of-line "crlf") 'undecided-dos)
+      (t 'undecided))
+    nil t))
 
 (defun editorconfig-set-trailing-nl (final-newline)
   "Set up requiring final newline by FINAL-NEWLINE."
   (cond
-   ((equal final-newline "true")
-    ;; keep prefs around how/when the nl is added, if set - otherwise add on save
-    (set      (make-local-variable 'require-final-newline)      (or require-final-newline t))
-    (set      (make-local-variable 'mode-require-final-newline) (or mode-require-final-newline t)))
-   ((equal final-newline "false")
-    ;; FIXME: Add functionality for actually REMOVING any trailing newlines here!
-    ;;        (rather than just making sure we don't automagically ADD a new one)
-    (set      (make-local-variable 'require-final-newline) nil)
-    (set      (make-local-variable 'mode-require-final-newline) nil))))
+    ((equal final-newline "true")
+      ;; keep prefs around how/when the nl is added, if set - otherwise add on save
+      (set      (make-local-variable 'require-final-newline)      (or require-final-newline t))
+      (set      (make-local-variable 'mode-require-final-newline) (or mode-require-final-newline t)))
+    ((equal final-newline "false")
+      ;; FIXME: Add functionality for actually REMOVING any trailing newlines here!
+      ;;        (rather than just making sure we don't automagically ADD a new one)
+      (set      (make-local-variable 'require-final-newline) nil)
+      (set      (make-local-variable 'mode-require-final-newline) nil))))
 
 (defun editorconfig-set-trailing-ws (trim-trailing-ws)
   "Set up trimming of trailing whitespace at end of lines by TRIM-TRAILING-WS."
@@ -271,16 +271,16 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
     ;; when true we push delete-trailing-whitespace (emacs > 21)
     ;; to write-file-functions
     (add-to-list
-     'write-file-functions
-     'delete-trailing-whitespace))
+      'write-file-functions
+      'delete-trailing-whitespace))
   (when (equal trim-trailing-ws "false")
     ;; when false we remove every delete-trailing-whitespace
     ;; from write-file-functions
     (setq
-     write-file-functions
-     (delete
-      'delete-trailing-whitespace
-      write-file-functions))))
+      write-file-functions
+      (delete
+        'delete-trailing-whitespace
+        write-file-functions))))
 
 (defun editorconfig-set-line-length (length)
   "Set the max line length (fill-column) to LENGTH."
@@ -299,12 +299,12 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   "Create properties hash table from PROPS-STRING."
   (let (props-list properties)
     (setq props-list (split-string props-string "\n")
-          properties (make-hash-table :test 'equal))
+      properties (make-hash-table :test 'equal))
     (dolist (prop props-list properties)
       (let ((key-val (split-string prop " *= *")))
         (when (> (length key-val) 1)
           (let ((key (intern (car key-val)))
-                (val (mapconcat 'identity (cdr key-val) "")))
+                 (val (mapconcat 'identity (cdr key-val) "")))
             (puthash key val properties)))))))
 
 (defun editorconfig-get-properties-from-exec ()

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -45,7 +45,9 @@
 
 (defcustom editorconfig-exec-path
   "editorconfig"
-  "EditorConfig command"
+  "EditorConfig executable name.
+
+This executable is invoked by `editorconfig-call-editorconfig-exec'."
   :type 'string
   :group 'editorconfig)
 (define-obsolete-variable-alias
@@ -68,23 +70,21 @@ property values as values."
   "0.5")
 
 (defcustom editorconfig-custom-hooks ()
-  "A list of custom hooks after loading common EditorConfig settings
+  "A list of custom hooks after loading common EditorConfig settings.
 
-Each element in this list is a hook function. This hook function takes one
-parameter, which is a property hash table. The value of properties can be
+Each element in this list is a hook function.  This hook function takes one
+parameter, which is a property hash table.  The value of properties can be
 obtained through gethash function.
 
 The hook does not have to be coding style related; you can add whatever
-functionality you want. For example, the following is an example to add a new
+functionality you want.  For example, the following is an example to add a new
 property emacs_linum to decide whether to show line numbers on the left
 
-(add-to-list 'editorconfig-custom-hooks
-  '(lambda (props)
-     (let ((show-line-num (gethash 'emacs_linum props)))
-       (cond ((equal show-line-num \"true\") (linum-mode 1))
-         ((equal show-line-num \"false\") (linum-mode 0))))))
-
-"
+  (add-to-list 'editorconfig-custom-hooks
+    '(lambda (props)
+       (let ((show-line-num (gethash 'emacs_linum props)))
+         (cond ((equal show-line-num \"true\") (linum-mode 1))
+           ((equal show-line-num \"false\") (linum-mode 0))))))"
   :type '(lambda (properties) (body))
   :group 'editorconfig)
 (define-obsolete-variable-alias
@@ -173,12 +173,13 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   "0.5")
 
 (defun editorconfig-string-integer-p (string)
-  "Whether a string representing integer"
+  "Return non-nil if STRING represents integer."
   (if (stringp string)
     (string-match-p "\\`[0-9]+\\'" string)
     nil))
 
 (defun editorconfig-set-indentation/python-mode (size)
+  "Set `python-mode' indent size to SIZE."
   (set (make-local-variable (if (or (> emacs-major-version 24)
                                     (and (= emacs-major-version 24)
                                          (>= emacs-minor-version 3)))
@@ -190,6 +191,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
     (set (make-local-variable 'py-indent-offset) size)))
 
 (defun editorconfig-set-indentation/latex-mode (size)
+  "Set `latex-mode' indent size to SIZE."
   (set (make-local-variable 'tex-indent-basic) size)
   (set (make-local-variable 'tex-indent-item) size)
   (set (make-local-variable 'tex-indent-arg) (* 2 size))
@@ -202,7 +204,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
     (set (make-local-variable 'LaTeX-item-indent) (- size))))
 
 (defun editorconfig-set-indentation (style &optional size tab_width)
-  "Set indentation type from given style and size"
+  "Set indentation type from STYLE, SIZE and TAB_WIDTH."
   (make-local-variable 'indent-tabs-mode)
   (make-local-variable 'tab-width)
   (if (editorconfig-string-integer-p size)
@@ -240,7 +242,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
                                        (t spec))))))))))))))
 
 (defun editorconfig-set-line-ending (end-of-line)
-  "Set line ending style to CR, LF, or CRLF"
+  "Set line ending style to CR, LF, or CRLF by END-OF-LINE."
   (set-buffer-file-coding-system
    (cond
     ((equal end-of-line "lf") 'undecided-unix)
@@ -250,6 +252,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
    nil t))
 
 (defun editorconfig-set-trailing-nl (final-newline)
+  "Set up requiring final newline by FINAL-NEWLINE."
   (cond
    ((equal final-newline "true")
     ;; keep prefs around how/when the nl is added, if set - otherwise add on save
@@ -262,7 +265,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
     (set      (make-local-variable 'mode-require-final-newline) nil))))
 
 (defun editorconfig-set-trailing-ws (trim-trailing-ws)
-  "set up trimming of trailing whitespace at end of lines"
+  "Set up trimming of trailing whitespace at end of lines by TRIM-TRAILING-WS."
   (make-local-variable 'write-file-functions) ;; just current buffer
   (when (equal trim-trailing-ws "true")
     ;; when true we push delete-trailing-whitespace (emacs > 21)
@@ -280,12 +283,12 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
       write-file-functions))))
 
 (defun editorconfig-set-line-length (length)
-  "set the max line length (fill-column)"
+  "Set the max line length (fill-column) to LENGTH."
   (when (editorconfig-string-integer-p length)
     (set-fill-column (string-to-number length))))
 
 (defun editorconfig-call-editorconfig-exec ()
-  "Call EditorConfig core and return output"
+  "Call EditorConfig core and return output."
   (let ((filename (buffer-file-name)))
     (with-temp-buffer
       (setq default-directory "/")
@@ -293,7 +296,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
       (buffer-string))))
 
 (defun editorconfig-parse-properties (props-string)
-  "Create properties hash table from string of properties"
+  "Create properties hash table from PROPS-STRING."
   (let (props-list properties)
     (setq props-list (split-string props-string "\n")
           properties (make-hash-table :test 'equal))
@@ -324,6 +327,7 @@ It calls `editorconfig-get-properties-from-exec' if
 
 ;;;###autoload
 (defun editorconfig-apply ()
+  "Apply EditorConfig properties for current buffer."
   (when buffer-file-name
     (let ((props (and (functionp editorconfig-get-properties-function)
                    (funcall editorconfig-get-properties-function))))


### PR DESCRIPTION
Some trivial fixes

* Fix docstring warnings reported by flycheck
* Fix commentary of editorconfig-core
* Make `editorconfig-apply` an interactive command
  * I think this is very useful: you can apply new EditorConfig properties without re-visiting the file
* Fix editorconfig.el indent
* Add document about running test