### PR TITLE
Throw error when broken conf & refactor error handlings

### DIFF
--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -165,26 +165,28 @@ If CONF is not found return nil."
                 (setq props nil))
               (setq pattern (match-string 1 line)))
 
-            ((string-match-p "=\\|:"
-               line)
-              ;; NOTE: Using match-string does not work as expected
-              (let* (
-                      (idx (string-match "=\\|:"
-                             line))
-                      (key (downcase (editorconfig-core-handle--string-trim (substring line
-                                                                              0
-                                                                              idx))))
-                      (value (editorconfig-core-handle--string-trim (substring line
-                                                                      (1+ idx))))
-                      )
-                (when (and (< (length key) 51)
-                        (< (length value) 256))
-                  (if pattern
-                    (when (< (length pattern) 4097)
-                      (setq props
-                        `(,@props (,key . ,value))))
-                    (setq top-props
-                      `(,@top-props (,key . ,value)))))))
+            (t
+              (let ((idx (string-match "=\\|:"
+                           line)))
+                (unless idx
+                  (error (format "Failed to parse file: %s"
+                           conf)))
+                (let (
+                       (key (downcase (editorconfig-core-handle--string-trim
+                                        (substring line
+                                          0
+                                          idx))))
+                       (value (editorconfig-core-handle--string-trim
+                                (substring line
+                                  (1+ idx)))))
+                  (when (and (< (length key) 51)
+                          (< (length value) 256))
+                    (if pattern
+                      (when (< (length pattern) 4097)
+                        (setq props
+                          `(,@props (,key . ,value))))
+                      (setq top-props
+                        `(,@top-props (,key . ,value))))))))
             )
           (forward-line 1))
         (when pattern

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -325,9 +325,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   "Get EditorConfig properties of current buffer by calling `editorconfig-exec-path'."
   (if (executable-find editorconfig-exec-path)
     (editorconfig-parse-properties (editorconfig-call-editorconfig-exec))
-    (display-warning :error
-      "Unable to find editorconfig executable.")
-    nil))
+    (error "Unable to find editorconfig executable")))
 
 (defun editorconfig-get-properties ()
   "Get EditorConfig properties of current buffer.

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -304,8 +304,10 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   (let ((filename (buffer-file-name)))
     (with-temp-buffer
       (setq default-directory "/")
-      (call-process editorconfig-exec-path nil t nil filename)
-      (buffer-string))))
+      (if (eq 0
+            (call-process editorconfig-exec-path nil t nil filename))
+        (buffer-string)
+        (error (buffer-string))))))
 
 (defun editorconfig-parse-properties (props-string)
   "Create properties hash table from PROPS-STRING."


### PR DESCRIPTION
* Throw errors when
  * editorconfig executable was not found
  * failed to parse .editorconfig
* Catch errors thrown from editorconfig-get-properties-function and show it with display-warning