### PR TITLE
Remove find-file-hook

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -363,9 +363,7 @@ It calls `editorconfig-get-properties-from-exec' if
   "Toggle EditorConfig feature."
   :global t
   :lighter ""
-  (dolist (hook (list
-                  'find-file-hook
-                  'after-change-major-mode-hook))
+  (dolist (hook '(after-change-major-mode-hook))
     (if editorconfig-mode
       (add-hook hook 'editorconfig-apply)
       (remove-hook hook 'editorconfig-apply))))


### PR DESCRIPTION
I found that we need not use find-file-hook when after-change-major-mode-hook is used because after-change-major-mode-hook is also called just after visiting files.
Currently editorconfig-apply is always called twice or more when visiting a file.

I'll leave the dolist loop as is so that we can easily add other hooks when we want :-)