### PR TITLE
add missing `web-mode-block-padding`

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -145,6 +145,7 @@ property emacs_linum to decide whether to show line numbers on the left
        web-mode-markup-indent-offset
        web-mode-css-indent-offset
        web-mode-code-indent-offset
+       web-mode-block-padding
        web-mode-script-padding
        web-mode-style-padding)
      (yaml-mode yaml-indent-offset))


### PR DESCRIPTION
https://github.com/fxbois/web-mode/blob/master/web-mode.el#L53

`web-mode-block-padding` defines

> Multi-line block (PHP, ruby, java, python, asp, etc.) left padding.

Without this defined, format goes like this:
```
<%!
  from views.utils import static, istatic
%>

<%inherit file="/card/base.html" />
<%namespace name="widgets" file="/card/widgets.html"/>

<%def name="title()">
    404 Oops...
</%def>
```

Code in template's self-defined blocks is not correctly indented.