### PR TITLE
Add function editorconfig-display-current-properties

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -358,6 +358,25 @@ It calls `editorconfig-get-properties-from-exec' if
     (editorconfig-core-get-properties-hash)))
 
 ;;;###autoload
+(defun editorconfig-display-current-properties ()
+  "Display EditorConfig properties extracted for current buffer."
+  (interactive)
+  (if editorconfig-properties-hash
+    (let (
+           (buf (get-buffer-create "*EditorConfig Properties*"))
+           (file buffer-file-name)
+           (props editorconfig-properties-hash))
+      (with-current-buffer buf
+        (erase-buffer)
+        (insert (format "# EditorConfig for %s\n" file))
+        (maphash (lambda (k v)
+                   (insert (format "%S = %s\n" k v)))
+          props))
+      (display-buffer buf))
+    (message "Properties are not applied to current buffer yet.")
+    nil))
+
+;;;###autoload
 (defun editorconfig-apply ()
   "Apply EditorConfig properties for current buffer."
   (interactive)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -188,6 +188,13 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   'editorconfig-indentation-alist
   "0.5")
 
+(defvar editorconfig-properties-hash nil
+  "Hash object of EditorConfig properties for current buffer.
+Set by `editorconfig-apply' and nil if that is not invoked in current buffer
+yet.")
+(make-variable-buffer-local 'editorconfig-properties-hash)
+
+
 (defun editorconfig-string-integer-p (string)
   "Return non-nil if STRING represents integer."
   (if (stringp string)
@@ -361,6 +368,7 @@ It calls `editorconfig-get-properties-from-exec' if
           (error "Invalid editorconfig-get-properties-function value"))
         (let ((props (funcall editorconfig-get-properties-function)))
           (progn
+            (setq editorconfig-properties-hash props)
             (editorconfig-set-indentation (gethash 'indent_style props)
               (gethash 'indent_size props)
               (gethash 'tab_width props))


### PR DESCRIPTION
This function will show editorconfig properties applied to current buffer, and just print message if editoconfig is not enabled yet for current buffer.

I think this function is useful for debugging: you can check

* If EditorConfig is properly enabled
* What properties have been applied to current buffer