### PR TITLE
Add link to MELPA Stable and deprecate Marmalade repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ and add the following to your `~/.emacs` file:
 ```
 
 Alternatively, you can find the package available on
-[MELPA](http://melpa.org/#/editorconfig).
+[MELPA](http://melpa.org/#/editorconfig) and [MELPA Stable](http://stable.melpa.org/#/editorconfig).
+
 
 ## Supported properties
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ and add the following to your `~/.emacs` file:
 ```
 
 Alternatively, you can find the package available on
-[MELPA](http://melpa.org/#/editorconfig) and [MELPA Stable](http://stable.melpa.org/#/editorconfig).
+[MELPA](http://melpa.org/#/editorconfig) and [MELPA Stable](http://stable.melpa.org/#/editorconfig)
+(there is also the package in [Marmalade](http://marmalade-repo.org/packages/editorconfig)
+repository, but currently we do not update that).
 
 
 ## Supported properties

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ and add the following to your `~/.emacs` file:
 ```
 
 Alternatively, you can find the package available on
-[Marmalade](http://marmalade-repo.org/packages/editorconfig) and
 [MELPA](http://melpa.org/#/editorconfig).
 
 ## Supported properties


### PR DESCRIPTION
Recently we do not update the package in Marmalade repository.