### PR TITLE
Load editorconfig-core explicitly just becore use

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -370,6 +370,7 @@ It calls `editorconfig-get-properties-from-exec' if
 `editorconfig-core-get-properties-hash'."
   (if (executable-find editorconfig-exec-path)
     (editorconfig-get-properties-from-exec)
+    (require 'editorconfig-core)
     (editorconfig-core-get-properties-hash)))
 
 ;;;###autoload


### PR DESCRIPTION
Fix for the case where this plugin is installed with `git clone`.
Additionally, When the core library is not available, it will emit a
more friendly error message like:

    Cannot open load file" "no such file or directory" "editorconfig-core"

#99 