### PR TITLE
Avoid askting coding system when neither charset nor end_of_line is specified

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -292,10 +292,12 @@ yet.")
                ((equal charset "utf-16be") 'utf-16be)
                ((equal charset "utf-16le") 'utf-16le)
                (t 'undecided))))
-    (set-buffer-file-coding-system (merge-coding-systems
-                                     cs
-                                     eol)
-      nil t)))
+    (unless (and (eq eol 'undecided)
+              (eq cs 'undecided))
+      (set-buffer-file-coding-system (merge-coding-systems
+                                       cs
+                                       eol)
+        nil t))))
 
 (defun editorconfig-set-trailing-nl (final-newline)
   "Set up requiring final newline by FINAL-NEWLINE."


### PR DESCRIPTION
Why ?
--------

**In short**: Emacs always asks which charset to use when editorconfig-mode is enabled, .editorconfig does not exist and trying to save files with non-ascii characters (at least when the user init file is empty). This is an annoying behavior so stop it.

Calling `set-buffer-file-coding-system` sets the "explicit" flag, and it is used just before saving files.
When this flag is set but the charset is `undecided`, Emacs asks users what charset to use for saving files with non-ascii characters (when this flag is not set Emacs do not ask and decide
to use something automatically, `utf-8` for my environment).

This typically happens when editing files in repositories without .editorconfig, and it is a bit annoying behavior.
This change makes this plugin not call `set-buffer-file-coding-system` at all when neither `charset` nor `end_of_line` is provided, thus Emacs can decide charset automatically when saving files in repositories without .editorconfig files.