### PR TITLE
Add editorconfig-exclude-prefixes

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -205,7 +205,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   :type '(repeat (symbol :tag "Major Mode"))
   :group 'editorconfig)
 
-(defcustom editorconfig-exclude-prefixes '(("\\`https?:" . t))
+(defcustom editorconfig-exclude-regexps '(("\\`https?:" . t))
   "List of buffer filename prefix regexp patterns not to apply properties."
   :type '(alist :key-type string :value-type boolean)
   :group 'editorconfig)
@@ -439,7 +439,7 @@ This function do the job only when the major mode is not listed in
              (not (memq major-mode
                         editorconfig-exclude-modes))
              buffer-file-name
-             (not (assoc-default buffer-file-name editorconfig-exclude-prefixes 'string-match)))
+             (not (assoc-default buffer-file-name editorconfig-exclude-regexps 'string-match)))
     (editorconfig-apply)))
 
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -207,7 +207,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
 
 (defcustom editorconfig-exclude-prefixes '(("\\`https?:" . t))
   "List of buffer filename prefix regexp patterns not to apply properties."
-  :type '(repeat (string))
+  :type '(alist :key-type string :value-type boolean)
   :group 'editorconfig)
 
 (defvar editorconfig-properties-hash nil

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -205,6 +205,11 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   :type '(repeat (symbol :tag "Major Mode"))
   :group 'editorconfig)
 
+(defcustom editorconfig-exclude-prefixes '(("\\`https?:" . t))
+  "List of buffer filename prefix regexp patterns not to apply properties."
+  :type '(repeat (string))
+  :group 'editorconfig)
+
 (defvar editorconfig-properties-hash nil
   "Hash object of EditorConfig properties for current buffer.
 Set by `editorconfig-apply' and nil if that is not invoked in current buffer
@@ -432,7 +437,9 @@ This function do the job only when the major mode is not listed in
 `editorconfig-exclude-modes'."
   (when (and major-mode
              (not (memq major-mode
-                        editorconfig-exclude-modes)))
+                        editorconfig-exclude-modes))
+             buffer-file-name
+             (not (assoc-default buffer-file-name editorconfig-exclude-prefixes 'string-match)))
     (editorconfig-apply)))
 
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -205,9 +205,9 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   :type '(repeat (symbol :tag "Major Mode"))
   :group 'editorconfig)
 
-(defcustom editorconfig-exclude-regexps '(("\\`https?:" . t))
+(defcustom editorconfig-exclude-regexps '("\\`https?:")
   "List of buffer filename prefix regexp patterns not to apply properties."
-  :type '(alist :key-type string :value-type boolean)
+  :type '(repeat string)
   :group 'editorconfig)
 
 (defvar editorconfig-properties-hash nil
@@ -439,7 +439,9 @@ This function do the job only when the major mode is not listed in
              (not (memq major-mode
                         editorconfig-exclude-modes))
              buffer-file-name
-             (not (assoc-default buffer-file-name editorconfig-exclude-regexps 'string-match)))
+             (not (cl-loop for regexp in editorconfig-exclude-regexps
+                           if (string-match regexp buffer-file-name) return t
+                           finally return nil)))
     (editorconfig-apply)))
 
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -39,6 +39,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(eval-when-compile (require 'rx))
 
 (declare-function editorconfig-core-get-properties-hash
                   "editorconfig-core"
@@ -206,7 +207,9 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
   :type '(repeat (symbol :tag "Major Mode"))
   :group 'editorconfig)
 
-(defcustom editorconfig-exclude-regexps '("\\`https?:")
+(defcustom editorconfig-exclude-regexps
+  (list (eval-when-compile
+          (rx string-start (or "http" "https" "ftp" "sftp" "rsync") ":")))
   "List of buffer filename prefix regexp patterns not to apply properties."
   :type '(repeat string)
   :group 'editorconfig)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -38,6 +38,7 @@
 ;; version control systems.
 
 ;;; Code:
+(require 'cl-lib)
 
 (declare-function editorconfig-core-get-properties-hash
                   "editorconfig-core"


### PR DESCRIPTION
## Problem

Warning occurred when you open a remote file.

### Steps to reproduce

```el
(find-file "http://httpbin.org/get")
```

The following error was encountered:

```
Error (editorconfig): .editorconfig/80 nodename nor servname provided, or not known.  Styles will not be applied.
```

## Solution

`editorconfig-exclude-prefixes` behaves as a blacklist for `editorconfig-mode-apply`.
This is a simplistic solution.  Any ideas?