### PR TITLE
use-package code in readme is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Or if you use [**use-package**](https://www.emacswiki.org/emacs/UsePackage):
 (use-package editorconfig
   :ensure t
   :init
-  (add-hook 'prog-mode-hook '(editorconfig-mode 1))
-  (add-hook 'text-mode-hook '(editorconfig-mode 1)))
+  (editorconfig-mode 1))
 ```
 
 ## Supported properties

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Alternatively, you can find the package available on
 
 Or if you use [**use-package**](https://www.emacswiki.org/emacs/UsePackage):
 
-```emacs-list
+```emacs-lisp
 (use-package editorconfig
   :ensure t
   :init
-  (add-hook 'prog-mode-hook (editorconfig-mode 1))
-  (add-hook 'text-mode-hook (editorconfig-mode 1)))
+  (add-hook 'prog-mode-hook '(editorconfig-mode 1))
+  (add-hook 'text-mode-hook '(editorconfig-mode 1)))
 ```
 
 ## Supported properties


### PR DESCRIPTION
The `use-package` code shown in the readme enters `editorconfig-mode` at package initialisation and adds the return value, `t`, to the hook lists. It should instead add the literal `'(editorconfig-mode 1)` to the lists.