### PR TITLE
[proposal] Unset indent_size for editorconfig.el

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,6 @@ insert_final_newline = true
 
 [*.el]
 indent_style = space
-indent_size = 2
 max_line_length = 80
 
 


### PR DESCRIPTION
https://github.com/editorconfig/editorconfig-emacs/pull/108#issuecomment-258657021

Indentation of the code for this project is very different from the general Emacs Lisp indentation rules.  `indent_size` rule looks like bad affinity to Lisp.

```el
;; [*.el] indent_size = 2
(defun editorconfig-mode-apply ()
  "Apply EditorConfig properties for current buffer.
This function do the job only when the major mode is not listed in
`editorconfig-exclude-modes'."
  (when (and major-mode
          (not (memq major-mode
                 editorconfig-exclude-modes))
          buffer-file-name
          (not (cl-loop for regexp in editorconfig-exclude-regexps
                 if (string-match regexp buffer-file-name) return t
                 finally return nil)))
    (editorconfig-apply)))

;; General Emacs Lisp indentation
(defun editorconfig-mode-apply ()
  "Apply EditorConfig properties for current buffer.
This function do the job only when the major mode is not listed in
`editorconfig-exclude-modes'."
  (when (and major-mode
             (not (memq major-mode
                        editorconfig-exclude-modes))
             buffer-file-name
             (not (cl-loop for regexp in editorconfig-exclude-regexps
                           if (string-match regexp buffer-file-name) return t
                           finally return nil)))
    (editorconfig-apply)))
```
