### PR TITLE
Add support for fsharp-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -118,6 +118,9 @@ show line numbers on the left:
     (emacs-lisp-mode lisp-indent-offset)
     (erlang-mode erlang-indent-level)
     (ess-mode ess-indent-offset)
+    (fsharp-mode fsharp-continuation-offset
+                 fsharp-indent-level
+                 fsharp-indent-offset)
     (groovy-mode c-basic-offset)
     (haskell-mode haskell-indent-spaces
                   haskell-indent-offset


### PR DESCRIPTION
F# is an open source, cross-platform, "functional-first" language, descendent
from the ML family.

The mode this commit adds support for is
https://github.com/fsharp/emacs-fsharp-mode (fsharp-mode on MELPA).