### PR TITLE
Add support for verilog-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -170,6 +170,12 @@ show line numbers on the left:
     (tcl-mode tcl-indent-level
               tcl-continued-indent-level)
     (typescript-mode typescript-indent-level)
+    (verilog-mode verilog-indent-level
+                  verilog-indent-level-behavioral
+                  verilog-indent-level-declaration
+                  verilog-indent-level-module
+                  verilog-cexp-indent
+                  verilog-case-indent)
     (web-mode (web-mode-indent-style . (lambda (size) 2))
               web-mode-markup-indent-offset
               web-mode-css-indent-offset


### PR DESCRIPTION
I'm not 100% sure about whether all these variables should be changed by editorconfig, but this should be every indentation setting in verilog. Let me know if I'm missing anything!

The variables I'm not sure about are `verilog-cexp-indent` and `verilog-case-indent`, which default to a different value from all the others, but I'm fairly sure that they control indentation (and therefore should be overriden by editorconfig indentation settings).

Thanks for looking at this! :smile: 