### PR TITLE
Set `fill-column` directly

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -376,7 +376,7 @@ TRIM-TRAILING-WS."
   "Set the max line length (`fill-column') to LENGTH."
   (when (and (editorconfig-string-integer-p length)
              (> (string-to-number length) 0))
-    (set-fill-column (string-to-number length))))
+    (setq fill-column (string-to-number length))))
 
 (defun editorconfig-call-editorconfig-exec ()
   "Call EditorConfig core and return output."


### PR DESCRIPTION
Set `fill-column` directly instead of using `set-fill-column`. That function is useful when used interactively, but when called from Lisp it’s almost equivalent to just setting `fill-column` directly, and it avoids showing the “Fill column set to…” message.