### PR TITLE
Add experimental file_type_emacs support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,6 @@ tab_width = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[.editorconfig]
+file_type_emacs = editorconfig-conf

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Current Emacs plugin coverage for EditorConfig's [properties][]:
   we just buffer-locally override any preferences that would auto-add them
   to files `.editorconfig` marks as trailing-newline-free
 * `max_line_length`
+* `file_type_emacs` (Experimental)
 * `root` (only used by EditorConfig core)
 
 Not yet covered properties marked with <del>over-strike</del>
@@ -66,6 +67,15 @@ ones that show up on our radar. Similarly, we don't yet hook
 in to all different packages for whitespace trimming to inform
 them about editorconfig settings, but aim for better coverage
 of things like [ws-trim](ftp://ftp.lysator.liu.se/pub/emacs/ws-trim.el).
+
+This plugin also has an experimental support for `file_type_emacs`,
+which specifies "file types" for files.
+As for Emacs, it means `major-mode` can be specified: for example,
+when `file_type_emacs` is set to `markdown` for `a.txt`,
+`markdown-mode` will be enabled when opening `a.txt`.
+This propertiy is experimental and its meaning might change in
+the future updates.
+
 
 ## Customize
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ which specifies "file types" for files.
 As for Emacs, it means `major-mode` can be specified: for example,
 when `file_type_emacs` is set to `markdown` for `a.txt`,
 `markdown-mode` will be enabled when opening `a.txt`.
-This propertiy is experimental and its meaning might change in
+This property is experimental and its meaning might change in
 the future updates.
 
 

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -45,6 +45,7 @@
   (let ((key-property-list
          '("charset"
            "end_of_line"
+           "file_type_emacs"
            "indent_size"
            "indent_style"
            "insert_final_newline"


### PR DESCRIPTION
https://github.com/editorconfig/editorconfig/issues/190

Fow now I just added support for `file_type_emacs` property (not a uniform name like `file_type`).