### PR TITLE
editorconfig-indentation-alist: fix groovy-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -135,7 +135,7 @@ show line numbers on the left:
     (fsharp-mode fsharp-continuation-offset
                  fsharp-indent-level
                  fsharp-indent-offset)
-    (groovy-mode c-basic-offset)
+    (groovy-mode groovy-indent-offset)
     (haskell-mode haskell-indent-spaces
                   haskell-indent-offset
                   haskell-indentation-layout-offset


### PR DESCRIPTION
groovy-mode recently added its own indent variable:
https://github.com/Groovy-Emacs-Modes/groovy-emacs-modes/commit/1f3872e01f