### PR TITLE
Avoid passing a non-absolute or non-existent file path to editorconfig(1)

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -426,7 +426,7 @@ FILETYPE should be s string like `\"ini\"`, if not nil or empty string."
                   (call-process editorconfig-exec-path nil t nil filename))
               (buffer-string)
             (error (buffer-string))))
-      (buffer-string))))
+      "")))
 
 (defun editorconfig-parse-properties (props-string)
   "Create properties hash table from PROPS-STRING."

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -417,13 +417,16 @@ FILETYPE should be s string like `\"ini\"`, if not nil or empty string."
 
 (defun editorconfig-call-editorconfig-exec ()
   "Call EditorConfig core and return output."
-  (let ((filename (buffer-file-name)))
-    (with-temp-buffer
-      (setq default-directory "/")
-      (if (eq 0
-              (call-process editorconfig-exec-path nil t nil filename))
-          (buffer-string)
-        (error (buffer-string))))))
+  (let* ((filename (buffer-file-name))
+         (filename (and filename (expand-file-name filename))))
+    (if filename
+        (with-temp-buffer
+          (setq default-directory "/")
+          (if (eq 0
+                  (call-process editorconfig-exec-path nil t nil filename))
+              (buffer-string)
+            (error (buffer-string))))
+      (buffer-string))))
 
 (defun editorconfig-parse-properties (props-string)
   "Create properties hash table from PROPS-STRING."


### PR DESCRIPTION
`buffer-file-name` can be programmatically set to anything, and if it points to something editorconfig(1) cannot deal with, the function gets the following error output.

```
Error (editorconfig): Input file must be a full path name.
.  Styles will not be applied.
```

I got the error when trying to use `helm-ag` with `helm-ag-use-temp-buffer` enabled.