### PR TITLE
Add variable to disable lisp-indent-offset sometimes

### DIFF
--- a/ert-tests/editorconfig.el
+++ b/ert-tests/editorconfig.el
@@ -25,6 +25,10 @@
   (concat default-directory
           "ert-tests/plugin-tests/test_files/"))
 
+(defvar editorconfig-secondary-ert-dir
+  (concat default-directory
+          "ert-tests/test_files_secondary/"))
+
 (ert-deftest test-editorconfig nil
   "Check if properties are applied."
   (editorconfig-mode 1)
@@ -39,4 +43,27 @@
     (should (eq python-indent-offset 4))
     (should (eq tab-width 8))
     (should (eq indent-tabs-mode nil)))
+  (editorconfig-mode -1))
+
+(ert-deftest test-lisp-use-default-indent nil
+  (editorconfig-mode 1)
+
+  (with-visit-file (concat editorconfig-secondary-ert-dir
+                     "2_space.el")
+    (should (eq lisp-indent-offset 2)))
+
+  (let ((editorconfig-lisp-use-default-indent t))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                       "2_space.el")
+      (should (eq lisp-indent-offset nil))))
+
+  (let ((editorconfig-lisp-use-default-indent 2))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                       "2_space.el")
+      (should (eq lisp-indent-offset nil))))
+
+  (let ((editorconfig-lisp-use-default-indent 4))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                       "2_space.el")
+      (should (eq lisp-indent-offset 2))))
   (editorconfig-mode -1))

--- a/ert-tests/test_files_secondary/.editorconfig
+++ b/ert-tests/test_files_secondary/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[2_space.el]
+indent_size = 2
+indent_style = tab

--- a/ert-tests/test_files_secondary/2_space.el
+++ b/ert-tests/test_files_secondary/2_space.el
@@ -1,0 +1,1 @@
+(print "hello world")


### PR DESCRIPTION
Sorry for the delay, I actually completely forgot about this...

I actually changed the spec of the variable from what I originally defined it as, the docstring is now:
```
Selectively ignore the value of indent_sizefor Lisp files.
Prevents `lisp-indent-offset' from being set selectively.

nil - `lisp-indent-offset' is always set normally.
t   - `lisp-indent-offset' is never set normally
       (always use default indent for lisps).
number - `lisp-indent-offset' is not set only if indent_size is
         equal to this number.  For example, if this is set to 2,
         `lisp-indent-offset'will not be set only if indent_size is 2.
```

Let me know if anything seems wrong here, since this is a pretty large change.

Closes #137