### PR TITLE
Add syntax highlighting for unset property value.

### DIFF
--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -54,7 +54,8 @@
            "tab_width"
            "trim_trailing_whitespace"))
         (key-value-list
-         '("true"
+         '("unset"
+           "true"
            "false"
            "lf"
            "cr"


### PR DESCRIPTION
This adds additional syntax highlighting in `editorconfig-conf-mode` for the **unset**  property value.

Related to https://github.com/editorconfig/editorconfig-emacs/issues/156.