### PR TITLE
Allow normal whitespace when reading EditorConfig settings file

### DIFF
--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -124,10 +124,10 @@ This function is a fnmatch with a few modification for EditorConfig usage."
                                     pattern))))
 
 (defsubst editorconfig-core-handle--string-trim (str)
-  "Remove leading and trailing whitespace from STR."
-  (replace-regexp-in-string "[ \t\n\r]+\\'"
+  "Remove leading and trailing whitespaces from STR."
+  (replace-regexp-in-string "[[:space:]]+\\'"
                             ""
-                            (replace-regexp-in-string "\\`[ \t\n\r]+"
+                            (replace-regexp-in-string "\\`[[:space:]]+"
                                                       ""
                                                       str)))
 

--- a/ert-tests/editorconfig-core-handle.el
+++ b/ert-tests/editorconfig-core-handle.el
@@ -47,4 +47,10 @@
                                                             (concat fixtures
                                                                     "a.js"))
                    '((("key" . "value"))))))
+
+  ;; For checking various normal whitespace (line breaks, horizontal space, vertical space, etc.)
+  (let* ((conf (concat default-directory
+                       "ert-tests/whitespaces/example-editorconfig.txt"))
+         (handle (editorconfig-core-handle conf)))
+    (should (editorconfig-core-handle-p handle)))
   )

--- a/ert-tests/whitespaces/example-editorconfig.txt
+++ b/ert-tests/whitespaces/example-editorconfig.txt
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+
+# Text encoding name.
+charset = utf-8
+
+# Page Break
+
+
+# Remove trailing whitespace on lines?
+trim_trailing_whitespace = true


### PR DESCRIPTION
Currently core-handle fails to parse files that contain whitespaces like line breaks, horizontal space, vertical space, etc.

Fixes #161 