### PR TITLE
use CURDIR instead of PWD in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TEXI_TOP := EditorConfig Emacs Plugin
 EMACS = emacs
 PANDOC = pandoc
 
-PROJECT_ROOT_DIR = $(PWD)
+PROJECT_ROOT_DIR = $(CURDIR)
 ERT_TESTS = $(wildcard $(PROJECT_ROOT_DIR)/ert-tests/*.el)
 TRAVIS_FILE = .travis.yml
 


### PR DESCRIPTION
During debian package build, the Makefile is called by debian/rules, which is also a Makefile. PWD is not propaged in recursive Makefile invocation, but CURDIR is:
https://www.gnu.org/software/make/manual/html_node/Recursion.html
found via: https://sourceforge.net/p/ipt-netflow/bugs-requests-patches/53/