### PR TITLE
Refactor fnmatch-p 

### DIFF
--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -55,8 +55,11 @@
 (require 'cl-lib)
 
 (defvar editorconfig-fnmatch--cache-hashtable
-  (make-hash-table :test 'equal)
+  nil
   "Cache of shell pattern and its translation.")
+;; Clear cache on file reload
+(setq editorconfig-fnmatch--cache-hashtable
+      (make-hash-table :test 'equal))
 
 
 (defconst editorconfig-fnmatch--left-brace-regexp


### PR DESCRIPTION
Now editorconfig-fnmatch-translate will return only translated regexp string so that the return value can be used from external code much more easily.