### PR TITLE
Update docs and metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ TRAVIS_FILE = .travis.yml
 BATCHFLAGS = -batch -q --no-site-file -L $(PROJECT_ROOT_DIR)
 
 MAIN_SRC = editorconfig.el
-SRCS = editorconfig.el editorconfig-core.el editorconfig-core-handle.el \
-	editorconfig-fnmatch.el
+SRCS = $(wildcard $(PROJECT_ROOT_DIR)/*.el)
 OBJS = $(SRCS:.el=.elc)
 
 $(OBJS): %.elc: %.el

--- a/README.md
+++ b/README.md
@@ -7,28 +7,19 @@
 
 This is an [EditorConfig][] plugin for [Emacs](https://www.gnu.org/software/emacs/).
 
-## Installation
 
-Download the [EditorConfig C Core][] and follow the instructions in the README
-and INSTALL files to install it.
+## Setup
 
-This plugin also has a built-in core library implemented in Emacs-Lisp, and
-fallback to it when no core executable is found.
-
-In either case, copy `.el` files in this repository to `~/.emacs.d/lisp`
-and add the following to your `~/.emacs` file:
+This package is available on [MELPA](https://melpa.org/#/editorconfig)
+and [MELPA Stable](https://stable.melpa.org/#/editorconfig).
+Install from there and enable global minor-mode `editorconfig-mode`:
 
 ```emacs-lisp
-(add-to-list 'load-path "~/.emacs.d/lisp")
-(require 'editorconfig)
 (editorconfig-mode 1)
 ```
 
-Alternatively, you can find the package available on
-[MELPA](https://melpa.org/#/editorconfig) and [MELPA Stable](https://stable.melpa.org/#/editorconfig)
-([The Marmalade package](http://marmalade-repo.org/packages/editorconfig) is deprecated).
-
-Or if you use [**use-package**](https://www.emacswiki.org/emacs/UsePackage):
+If you use [**use-package**](https://www.emacswiki.org/emacs/UsePackage),
+add the following:
 
 ```emacs-lisp
 (use-package editorconfig
@@ -36,6 +27,30 @@ Or if you use [**use-package**](https://www.emacswiki.org/emacs/UsePackage):
   :config
   (editorconfig-mode 1))
 ```
+
+
+To install manually copy all `.el` files in this repository to
+`~/.emacs.d/lisp`  and add the following to your `init.el` file:
+
+```emacs-lisp
+(add-to-list 'load-path "~/.emacs.d/lisp")
+(require 'editorconfig)
+(editorconfig-mode 1)
+```
+
+### Install a Core Program
+
+This package requires a Core program.
+The officially recommended one is [EditorConfig C Core][],
+follow the instructions in the README and INSTALL files to install it.
+
+Though using C Core is recommended, but this plugin also
+includes a core library implemented in Emacs Lisp.
+This plugin uses this as a fallback method when no core executable
+is found, so it works out-of-the-box without explicitly installing
+any other core program.
+
+
 
 ## Supported properties
 
@@ -90,6 +105,12 @@ future updates. When both are specified, `file_type_ext` takes precedence.
 
 ## Customize
 
+`editorconfig-emacs` provides some customize variables.
+
+Here are some of these variables: for the full list of available variables, 
+type <kbd>M-x customize-group [RET] editorconfig [RET]</kbd>.
+
+
 ### `editorconfig-after-apply-functions`
 
 (Formerly `editorconfig-custom-hooks`)
@@ -107,6 +128,7 @@ only blocks of `web-mode`: it can be achieved by adding following to your init.e
 ```
 
 You can also define your own custom properties and enable them here.
+
 
 ### `editorconfig-hack-properties-functions`
 
@@ -128,6 +150,7 @@ overwrite \"indent_style\" property when current `major-mode` is a
 
 ```
 
+
 ### `editorconfig-indentation-alist`
 
 Alist of indentation setting methods by modes.
@@ -141,52 +164,18 @@ add a pair of major-mode symbol and its indentation variables:
   '(c-mode c-basic-offset))
 ```
 
-You can also modify this variable with the command
-<kbd>M-x customize-variable [RET] editorconfig-indentation-alist [RET]</kbd>.
-For a bit more complicated cases please take a look at the docstring of this variable.
-
-### `editorconfig-exec-path`
-
-String of `editorconfig` executable name (command name or full path to
-the executable).
-
-
-### `editorconfig-get-properties-function`
-
-Function to use to get EditorConfig properties.
-
-For example, if you always want to use built-in core library instead
-of any EditorConfig executable to get properties, add following to
-your init.el:
-
-``` emacs-lisp
-(set-variable 'editorconfig-get-properties-function
-              #'editorconfig-core-get-properties-hash)
-```
-
-Possible known values are:
-
-* `editorconfig-get-properties` (default)
-  * Use `editorconfig-get-properties-from-exec` when
-    `editorconfig-exec-path` executable is found, otherwise use
-    `editorconfig-core-get-properties-hash`
-* `editorconfig-get-properties-from-exec`
-  * Get properties by executing EditorConfig executable specified in
-    `editorconfig-exec-path`
-* `editorconfig-core-get-properties-hash`
-  * Always use built-in Emacs-Lisp implementation to get properties
-
 
 ### `editorconfig-trim-whitespaces-mode`
 
 Buffer local minor-mode to use to trim trailing whitespaces.
 
-If set, enable that mode when `trim_trailing_whitespace` is set to true.
-Otherwise, use `delete-trailing-whitespace`.
+If set, enable/disable that mode in accord with `trim_trailing_whitespace`
+property in `.editorconfig`.
+Otherwise, use Emacs built-in `delete-trailing-whitespace` function.
 
 One possible value is
 [`ws-butler-mode`](https://github.com/lewang/ws-butler), with which
-only lines touched get trimmed. To use it, add following to yo
+only lines touched get trimmed. To use it, add following to your
 init.el:
 
 ``` emacs-lisp

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ only blocks of `web-mode`: it can be achieved by adding following to your init.e
 
 ```emacs-lisp
 (add-hook 'editorconfig-after-apply-functions
-  (lambda (hash) (setq web-mode-block-padding 0)))
+  (lambda (props) (setq web-mode-block-padding 0)))
 ```
 
 You can also define your own custom properties and enable them here.

--- a/bin/editorconfig-el
+++ b/bin/editorconfig-el
@@ -5,7 +5,7 @@
 
 ;; editorconfig-el --- EditorConfig Core executable in Emacs Lisp
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-conf-mode.el --- Major mode for editing .editorconfig files
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -1,10 +1,11 @@
-;;; editorconfig-conf-mode.el --- Major mode for editing .editorconfig files
+;;; editorconfig-conf-mode.el --- Major mode for editing .editorconfig files  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
 ;; Version: 0.7.14
+;; Package-Requires: ((emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
@@ -75,16 +76,18 @@
 
     ;; Highlight all key values
     (dolist (key-value key-value-list)
-      (add-to-list
-       'font-lock-value
+      (push
        `(,(format "[=:][ \t]*\\(%s\\)\\([ \t]\\|$\\)" key-value)
-         1 font-lock-constant-face)))
+         1 font-lock-constant-face)
+       font-lock-value
+       ))
     ;; Highlight all key properties
     (dolist (key-property key-property-list)
-      (add-to-list
-       'font-lock-value
+      (push
        `(,(format "^[ \t]*\\(%s\\)[ \t]*[=:]" key-property)
-         1 font-lock-builtin-face)))
+         1 font-lock-builtin-face)
+       font-lock-value
+       ))
 
     (conf-mode-initialize "#" font-lock-value)))
 

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -4,6 +4,7 @@
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
+;; Version: 0.7.14
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-core-handle.el --- Handle Class for EditorConfig File
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -53,7 +53,7 @@ Slots:
   (props nil))
 
 (defun editorconfig-core-handle-section-get-properties (section file dir)
-  "Return properties alist when SECTION name matches FILE.
+  "Return properties alist when SECTION name match FILE.
 
 DIR should be where the directory where .editorconfig which has SECTION exists.
 IF not match, return nil."

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -1,10 +1,11 @@
-;;; editorconfig-core-handle.el --- Handle Class for EditorConfig File
+;;; editorconfig-core-handle.el --- Handle Class for EditorConfig File  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
 ;; Version: 0.7.14
+;; Package-Requires: ((emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -4,6 +4,7 @@
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
+;; Version: 0.7.14
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -40,10 +40,16 @@
   "Hash of EditorConfig filename and its `editorconfig-core-handle' instance.")
 
 (cl-defstruct editorconfig-core-handle-section
-  ;; String of section name (glob string)
+  "Structure representing one section in a .editorconfig file.
+
+Slots:
+
+`name'
+  String of section name (glob string).
+
+`props'
+  Alist of properties: (KEY . VALUE)."
   (name nil)
-  ;; Alist of properties
-  ;; (KEY . VALUE)
   (props nil))
 
 (defun editorconfig-core-handle-section-get-properties (section file dir)
@@ -58,17 +64,24 @@ IF not match, return nil."
     (editorconfig-core-handle-section-props section)))
 
 (cl-defstruct editorconfig-core-handle
-  ;; Alist of top propetties
-  ;; e.g. (("root" . "true"))
+  "Structure representing an .editorconfig file.
+
+Slots:
+`top-props'
+  Alist of top propetties like ((\"root\" . \"true\"))
+
+`sections'
+  List of `editorconfig-core-hadnle-section' strucure object.
+
+`mtime'
+  Last modified time of .editorconfig file.
+
+`path'
+  Absolute path to .editorconfig file.'
+"
   (top-props nil)
-
-  ;; List of editorconfig-core-handle-section
   (sections nil)
-
-  ;; e.g. (22310 59113 203882 991000)
   (mtime nil)
-
-  ;; e.g. "/home/a/b/.editorconfig"
   (path nil))
 
 

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -57,7 +57,7 @@ Slots:
 (defun editorconfig-core-handle-section-get-properties (section file dir)
   "Return properties alist when SECTION name match FILE.
 
-DIR should be where the directory where .editorconfig which has SECTION exists.
+DIR should be the directory where .editorconfig file which has SECTION lives.
 IF not match, return nil."
   (when (editorconfig-core-handle--fnmatch-p
          file

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -26,8 +26,8 @@
 
 ;;; Commentary:
 
-;; Handle class for EditorConfig config file.  This library is used internally
-;; from editorconfig-core.el .
+;; Handle structures for EditorConfig config file.  This library is used
+;; internally from editorconfig-core.el .
 
 ;;; Code:
 

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -251,7 +251,6 @@ If CONF is not found return nil."
            )
           (setq current-line-number
                 (1+ current-line-number))
-          ;; Use  this code instead of goto-line for Lisp program
           (goto-char (point-min))
           (forward-line (1- current-line-number))
           )

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-core.el --- EditorConfig Core library in Emacs Lisp
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -4,6 +4,7 @@
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
+;; Version: 0.7.14
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -1,10 +1,11 @@
-;;; editorconfig-core.el --- EditorConfig Core library in Emacs Lisp
+;;; editorconfig-core.el --- EditorConfig Core library in Emacs Lisp  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
 ;; Version: 0.7.14
+;; Package-Requires: ((emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -4,6 +4,7 @@
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
+;; Version: 0.7.14
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -1,10 +1,11 @@
-;;; editorconfig-fnmatch.el --- Glob pattern matching in Emacs lisp
+;;; editorconfig-fnmatch.el --- Glob pattern matching in Emacs lisp  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
 ;; Version: 0.7.14
+;; Package-Requires: ((emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-fnmatch.el --- Glob pattern matching in Emacs lisp
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -195,7 +195,7 @@ overwrite \"indent_style\" property when current `major-mode' is a
     (js3-mode js3-indent-level)
     (json-mode js-indent-level)
     (julia-mode julia-indent-offset)
-    (latex-mode . editorconfig-set-indentation/latex-mode)
+    (latex-mode . editorconfig-set-indentation-latex-mode)
     (lisp-mode lisp-indent-offset)
     (livescript-mode livescript-tab-width)
     (lua-mode lua-indent-level)
@@ -215,7 +215,7 @@ overwrite \"indent_style\" property when current `major-mode' is a
     (ps-mode ps-mode-tab)
     (pug-mode pug-tab-width)
     (puppet-mode puppet-indent-level)
-    (python-mode . editorconfig-set-indentation/python-mode)
+    (python-mode . editorconfig-set-indentation-python-mode)
     (ruby-mode ruby-indent-level)
     (rust-mode rust-indent-offset)
     (scala-mode scala-indent:step)
@@ -327,7 +327,7 @@ number - `lisp-indent-offset' is not set only if indent_size is
   (and (stringp string)
        (string-match-p "\\`[0-9]+\\'" string)))
 
-(defun editorconfig-set-indentation/python-mode (size)
+(defun editorconfig-set-indentation-python-mode (size)
   "Set `python-mode' indent size to SIZE."
   (set (make-local-variable (if (or (> emacs-major-version 24)
                                     (and (= emacs-major-version 24)
@@ -339,7 +339,7 @@ number - `lisp-indent-offset' is not set only if indent_size is
   (when (boundp 'py-indent-offset)
     (set (make-local-variable 'py-indent-offset) size)))
 
-(defun editorconfig-set-indentation/latex-mode (size)
+(defun editorconfig-set-indentation-latex-mode (size)
   "Set `latex-mode' indent size to SIZE."
   (set (make-local-variable 'tex-indent-basic) size)
   (set (make-local-variable 'tex-indent-item) size)
@@ -484,7 +484,7 @@ FILETYPE should be s string like `\"ini\"`, if not nil or empty string."
                                    "-mode")))))
     (when mode
       (if (fboundp mode)
-          (editorconig-apply-major-mode-safely mode)
+          (editorconfig-apply-major-mode-safely mode)
         (display-warning :error (format "Major-mode `%S' not found"
                                         mode))
         nil))))
@@ -496,7 +496,7 @@ FILETYPE should be s string like `\"ini\"`, if not nil or empty string."
      'permanent-local
      t)
 
-(defun editorconig-apply-major-mode-safely (mode)
+(defun editorconfig-apply-major-mode-safely (mode)
   "Set `major-mode' to MODE.
 Normally `editorconfig-apply' will be hooked so that it runs when changing
 `major-mode', so there is a possibility that MODE is called infinitely if

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -78,7 +78,26 @@ This executable is invoked by `editorconfig-call-editorconfig-exec'."
 This function will be called with no argument and should return a
 hash object containing properties, or nil if any core program is
 not available.  The hash object should have symbols of property
-names as keys and strings of property values as values."
+names as keys and strings of property values as values.
+
+
+For example, if you always want to use built-in core library instead
+of any EditorConfig executable to get properties, add following to
+your init.el:
+
+(set-variable 'editorconfig-get-properties-function
+              #'editorconfig-core-get-properties-hash)
+
+Possible known values are:
+
+* `editorconfig-get-properties' (default)
+  * Use `editorconfig-get-properties-from-exec' when
+    `editorconfig-exec-path' executable executable is found, otherwise
+    use `editorconfig-core-get-properties-hash'
+* `editorconfig-get-properties-from-exec'
+  * Get properties by executing EditorConfig executable
+* `editorconfig-core-get-properties-hash'
+  * Always use built-in Emacs-Lisp implementation to get properties"
   :type 'function
   :group 'editorconfig)
 (define-obsolete-variable-alias

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -1,6 +1,6 @@
 ;;; editorconfig.el --- EditorConfig Emacs Plugin
 
-;; Copyright (C) 2011-2017 EditorConfig Team
+;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; Version: 0.7.14

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -596,35 +596,6 @@ It calls `editorconfig-get-properties-from-exec' if
     (editorconfig-core-get-properties-hash)))
 
 ;;;###autoload
-(defun editorconfig-find-current-editorconfig ()
-  "Find the closest .editorconfig file for current file."
-  (interactive)
-  (eval-and-compile (require 'editorconfig-core))
-  (let ((file (editorconfig-core-get-nearest-editorconfig
-               default-directory)))
-    (when file
-      (find-file file))))
-
-;;;###autoload
-(defun editorconfig-display-current-properties ()
-  "Display EditorConfig properties extracted for current buffer."
-  (interactive)
-  (if editorconfig-properties-hash
-      (let (
-            (buf (get-buffer-create "*EditorConfig Properties*"))
-            (file buffer-file-name)
-            (props editorconfig-properties-hash))
-        (with-current-buffer buf
-          (erase-buffer)
-          (insert (format "# EditorConfig for %s\n" file))
-          (maphash (lambda (k v)
-                     (insert (format "%S = %s\n" k v)))
-                   props))
-        (display-buffer buf))
-    (message "Properties are not applied to current buffer yet.")
-    nil))
-
-;;;###autoload
 (defun editorconfig-apply ()
   "Apply EditorConfig properties for current buffer.
 This function ignores `editorconfig-exclude-modes' and always
@@ -682,16 +653,6 @@ in `editorconfig-exclude-modes'."
                            finally return nil)))
     (editorconfig-apply)))
 
-(defun editorconfig-format-buffer()
-  "Format buffer according to .editorconfig indent_style and indent_width."
-  (interactive)
-  (if (string= (gethash 'indent_style editorconfig-properties-hash) "tab")
-      (tabify (point-min) (point-max)))
-  (if (string= (gethash 'indent_style editorconfig-properties-hash) "space")
-      (untabify (point-min) (point-max)))
-  (indent-region (point-min) (point-max)))
-
-
 ;;;###autoload
 (define-minor-mode editorconfig-mode
   "Toggle EditorConfig feature.
@@ -707,6 +668,53 @@ mode is not listed in `editorconfig-exclude-modes'."
     (if editorconfig-mode
         (add-hook hook 'editorconfig-mode-apply)
       (remove-hook hook 'editorconfig-mode-apply))))
+
+
+;; Tools
+;; Some useful commands for users, not required for EditorConfig to work
+
+;;;###autoload
+(defun editorconfig-find-current-editorconfig ()
+  "Find the closest .editorconfig file for current file."
+  (interactive)
+  (eval-and-compile (require 'editorconfig-core))
+  (let ((file (editorconfig-core-get-nearest-editorconfig
+               default-directory)))
+    (when file
+      (find-file file))))
+
+;;;###autoload
+(defun editorconfig-display-current-properties ()
+  "Display EditorConfig properties extracted for current buffer."
+  (interactive)
+  (if editorconfig-properties-hash
+      (let (
+            (buf (get-buffer-create "*EditorConfig Properties*"))
+            (file buffer-file-name)
+            (props editorconfig-properties-hash))
+        (with-current-buffer buf
+          (erase-buffer)
+          (insert (format "# EditorConfig for %s\n" file))
+          (maphash (lambda (k v)
+                     (insert (format "%S = %s\n" k v)))
+                   props))
+        (display-buffer buf))
+    (message "Properties are not applied to current buffer yet.")
+    nil))
+;;;###autoload
+(defalias 'describe-editorconfig-properties
+  'editorconfig-display-current-properties)
+
+;;;###autoload
+(defun editorconfig-format-buffer()
+  "Format buffer according to .editorconfig indent_style and indent_width."
+  (interactive)
+  (if (string= (gethash 'indent_style editorconfig-properties-hash) "tab")
+      (tabify (point-min) (point-max)))
+  (if (string= (gethash 'indent_style editorconfig-properties-hash) "space")
+      (untabify (point-min) (point-max)))
+  (indent-region (point-min) (point-max)))
+
 
 (provide 'editorconfig)
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -1,11 +1,11 @@
-;;; editorconfig.el --- EditorConfig Emacs Plugin
+;;; editorconfig.el --- EditorConfig Emacs Plugin  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2019 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; Version: 0.7.14
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -545,7 +545,7 @@ EXT should be a string like `\"ini\"`, if not nil or empty string."
     (let ((mode (editorconfig--find-mode-from-ext ext
                                                   buffer-file-name)))
       (if mode
-            (editorconig-apply-major-mode-safely mode)
+          (editorconfig-apply-major-mode-safely mode)
         (display-warning :error (format "Major-mode for `%s' not found"
                                         ext))
         nil))))

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -87,8 +87,7 @@ names as keys and strings of property values as values."
   "0.5")
 
 (defcustom editorconfig-mode-lighter " EditorConfig"
-  "Lighter displayed in mode line
-when `editorconfig-mode' is enabled."
+  "Lighter displayed in mode line when function `editorconfig-mode' is enabled."
   :type 'string
   :group 'editorconfig)
 
@@ -139,7 +138,7 @@ overwrite \"indent_style\" property when current `major-mode' is a
   :group 'editorconfig)
 
 (defcustom editorconfig-indentation-alist
-  ;; For contributors: Sort modes in alphabetical order, please :)
+  ;; For contributors: Sort modes in alphabetical order
   '((apache-mode apache-indent-level)
     (awk-mode c-basic-offset)
     (c++-mode c-basic-offset)
@@ -272,8 +271,7 @@ NOTE: Only the **buffer local** value of VARIABLE will be set."
 (defcustom editorconfig-exclude-regexps
   (list (eval-when-compile
           (rx string-start (or "http" "https" "ftp" "sftp" "rsync") ":")))
-  "List of buffer filename prefix regexp patterns not to apply
-properties."
+  "List of buffer filename prefix regexp patterns not to apply properties."
   :type '(repeat string)
   :group 'editorconfig)
 
@@ -411,8 +409,10 @@ number - `lisp-indent-offset' is not set only if indent_size is
                                      nil t))))
 
 (defun editorconfig-set-trailing-nl (final-newline)
-  "Set up requiring final newline (`require-final-newline' and
-`mode-require-final-newline') by FINAL-NEWLINE."
+  "Set up requiring final newline by FINAL-NEWLINE.
+
+This function will set `require-final-newline' and `mode-require-final-newline'
+to non-nil when FINAL-NEWLINE is true."
   (cond
    ((equal final-newline "true")
     ;; keep prefs around how/when the nl is added, if set - otherwise add on save
@@ -557,8 +557,9 @@ EXT should be a string like `\"ini\"`, if not nil or empty string."
             (puthash key val properties)))))))
 
 (defun editorconfig-get-properties-from-exec ()
-  "Get EditorConfig properties of current buffer by calling
-`editorconfig-exec-path'."
+  "Get EditorConfig properties of current buffer.
+
+This function uses value of `editorconfig-exec-path' to get properties."
   (if (executable-find editorconfig-exec-path)
       (editorconfig-parse-properties (editorconfig-call-editorconfig-exec))
     (error "Unable to find editorconfig executable")))
@@ -663,7 +664,7 @@ in `editorconfig-exclude-modes'."
     (editorconfig-apply)))
 
 (defun editorconfig-format-buffer()
-  "Format buffer according to .editorconfig indent_style and indent_width"
+  "Format buffer according to .editorconfig indent_style and indent_width."
   (interactive)
   (if (string= (gethash 'indent_style editorconfig-properties-hash) "tab")
       (tabify (point-min) (point-max)))


### PR DESCRIPTION
- Follow MELPA guidelines
  https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org
  https://github.com/melpa/melpa/blob/master/.github/PULL_REQUEST_TEMPLATE.md
  - Pass M-x checkdoc
  - Pass package-lint
    - Except for `1:1: warning: Including "Emacs" in the package description is usually redundant.`
    - I want to keep this to say that editorconfig is an editor independent project and there are other packages/libraries/extensions for other editors
  - Use lexical-binging: t
- Other document fixes
- 2019