### PR TITLE
Add support for bpftrace-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -160,6 +160,7 @@ overwrite \"indent_style\" property when current `major-mode' is a
   ;; For contributors: Sort modes in alphabetical order
   '((apache-mode apache-indent-level)
     (awk-mode c-basic-offset)
+    (bpftrace-mode c-basic-offset)
     (c++-mode c-basic-offset)
     (c-mode c-basic-offset)
     (cmake-mode cmake-tab-width)


### PR DESCRIPTION
I created a [new mode](https://gitlab.com/jgkamat/bpftrace-mode) for bpftrace, which is based on c-mode, and this patch adds support for indentation via `c-basic-offset`.