### PR TITLE
F90 mode

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Steve Jordan
 Hong Xu
 10sr
 Usami Kenta
+Izaak "Zaak" Beekman

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -173,6 +173,13 @@ overwrite \"indent_style\" property when current `major-mode' is a
     (enh-ruby-mode enh-ruby-indent-level)
     (erlang-mode erlang-indent-level)
     (ess-mode ess-indent-offset)
+    (f90-mode f90-associate-indent
+              f90-continuation-indent
+              f90-critical-indent
+              f90-do-indent
+              f90-if-indent
+              f90-program-indent
+              f90-type-indent)
     (feature-mode feature-indent-offset
                   feature-indent-level)
     (fsharp-mode fsharp-continuation-offset


### PR DESCRIPTION
Add out of the box support for f90-mode (modern Fortran, F90, F95, F03, F08, F18)

Old school Fortran <= 77 probably cannot use editorconfig since the first 7(?) columns are reserved and have special meaning and uses a different major mode.