### PR TITLE
Always handle "unset" values as non-present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Define -mode-apply as an interactive command (#216)
 - Use elisp core by default (#209)
+- User functions in the hooks `editorconfig-hack-properties-functions` and
+  `editorconfig-after-apply-functions` can no longer distinguish explicitly
+  unset properties from ones that were never set in the first place.  (#222)
 
 
 ## [0.8.1] - 2019-10-10

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -67,10 +67,10 @@ IF not match, return nil."
 
 Slots:
 `top-props'
-  Alist of top propetties like ((\"root\" . \"true\"))
+  Alist of top properties like ((\"root\" . \"true\"))
 
 `sections'
-  List of `editorconfig-core-hadnle-section' strucure object.
+  List of `editorconfig-core-handle-section' structure objects.
 
 `mtime'
   Last modified time of .editorconfig file.

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -118,7 +118,7 @@ This functions returns alist of properties.  Each element will look like
     result))
 
 (defun editorconfig-core--hash-merge (into update)
-  "Merge to hashes INTO and UPDATE.
+  "Merge two hashes INTO and UPDATE.
 
 This is a destructive function, hash INTO will be modified.
 When the same key exists in both two hashes, values of UPDATE takes precedence."

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -72,7 +72,7 @@
 
 (defconst editorconfig-fnmatch--numeric-range-regexp
   "\\([+-]?[0-9]+\\)\\.\\.\\([+-]?[0-9]+\\)"
-  "Regular expression for numaric range (like {-3..+3}).")
+  "Regular expression for numeric range (like {-3..+3}).")
 
 (defun editorconfig-fnmatch--match-num (regexp string)
   "Return how many times REGEXP is found in STRING."

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -388,14 +388,13 @@ number - `lisp-indent-offset' is not set only if indent_size is
 
 (defun editorconfig-set-indentation (style &optional size tab_width)
   "Set indentation type from STYLE, SIZE and TAB_WIDTH."
-  (make-local-variable 'indent-tabs-mode)
-  (make-local-variable 'tab-width)
   (if (editorconfig-string-integer-p size)
       (setq size (string-to-number size))
     (when (not (equal size "tab")) (setq size nil)))
-  (setq tab-width (cond (tab_width (string-to-number tab_width))
-                        ((numberp size) size)
-                        (t tab-width)))
+  (cond (tab_width
+         (setq tab-width (string-to-number tab_width)))
+        ((numberp size)
+         (setq tab-width size)))
   (when (equal size "tab")
     (setq size tab-width))
   (cond ((equal style "space")

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -799,7 +799,7 @@ version in the echo area and the messages buffer."
             (require 'lisp-mnt)
             (lm-version)))
          (pkg
-          (and (require 'package nil t)
+          (and (eval-and-compile (require 'package nil t))
                (cadr (assq 'editorconfig
                            package-alist))))
          (pkg-version

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -614,7 +614,7 @@ EXT should be a string like `\"ini\"`, if not nil or empty string."
   "Create properties hash table from PROPS-STRING."
   (let (props-list properties)
     (setq props-list (split-string props-string "\n")
-          properties (make-hash-table :test 'equal))
+          properties (make-hash-table))
     (dolist (prop props-list properties)
       (let ((key-val (split-string prop " *= *")))
         (when (> (length key-val) 1)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -73,7 +73,7 @@ Used by `editorconfig-call-editorconfig-exec'."
 
 (defcustom editorconfig-get-properties-function
   'editorconfig-core-get-properties-hash
-  "A function which gets EditorConofig properties for current buffer.
+  "A function which gets EditorConfig properties for current buffer.
 
 This function will be called with no argument and should return a
 hash object containing properties, or nil if any core program is
@@ -94,7 +94,7 @@ Possible known values are:
   * Always use built-in Emacs-Lisp implementation to get properties
 * `editorconfig-get-properties'
   * Use `editorconfig-get-properties-from-exec' when
-    `editorconfig-exec-path' executable executable is found, otherwise
+    `editorconfig-exec-path' executable is found, otherwise
     use `editorconfig-core-get-properties-hash'
 * `editorconfig-get-properties-from-exec'
   * Get properties by executing EditorConfig executable"
@@ -333,7 +333,7 @@ current buffer yet.")
      t)
 
 (defvar editorconfig-lisp-use-default-indent nil
-  "Selectively ignore the value of indent_sizefor Lisp files.
+  "Selectively ignore the value of indent_size for Lisp files.
 Prevents `lisp-indent-offset' from being set selectively.
 
 nil - `lisp-indent-offset' is always set normally.
@@ -341,7 +341,7 @@ t   - `lisp-indent-offset' is never set normally
        (always use default indent for lisps).
 number - `lisp-indent-offset' is not set only if indent_size is
          equal to this number.  For example, if this is set to 2,
-         `lisp-indent-offset'will not be set only if indent_size is 2.")
+         `lisp-indent-offset' will not be set only if indent_size is 2.")
 
 (defconst editorconfig-unset-value "unset"
   "String of value used to unset properties in .editorconfig .")
@@ -786,7 +786,7 @@ To disable EditorConfig in some buffers, modify
 (declare-function lm-version "lisp-mnt" nil)
 
 ;;;###autoload
-(defun  editorconfig-version (&optional show-version)
+(defun editorconfig-version (&optional show-version)
   "Get EditorConfig version as string.
 
 If called interactively or if SHOW-VERSION is non-nil, show the


### PR DESCRIPTION
According to [the editorconfig specification][1],

> For any pair, a value of `unset` removes the effect of that pair, even if it has been set before. For example, add `indent_size = unset` to undefine the `indent_size` pair (and use editor defaults).

Yet, the test suite for editorconfig *cores* [indicates][2] that an editorconfig shouldn't ignore values of "unset", and should return them as-is.

Therefore it's up to editorconfig *plugins* to discard values of "unset" at the point of use.

Before this commit, the only place in the code where the value "unset" was checked for was in `editorconfig-set-major-mode-from-ext`, whereas in other places, such as `editorconfig-set-indentation`, it was not checked.

After this commit, values of "unset" are immediately removed from the properties hashtable before it is used to do anything in `editorconfig-apply`.  This ensures that properties with value "unset" will be treated indistinguishably from unspecified properties.

This fixes the behavior shown in [this gist](https://gist.github.com/kini/560673dbff4b8e42bb40a82a8ca6e5b1) (the gist can be cloned locally and opened in Emacs to demonstrate the behavior).

[1]: https://editorconfig-specification.readthedocs.io/en/latest/#supported-pairs
[2]: https://github.com/editorconfig/editorconfig-core-test/issues/12