### PR TITLE
editorconfig.el: skip special-mode buffers when applying (#246)

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -717,6 +717,7 @@ This function does nothing when the major mode is listed in
 any of regexps in `editorconfig-exclude-regexps'."
   (interactive)
   (when (and major-mode
+             (not (derived-mode-p 'special-mode))
              (not (memq major-mode
                         editorconfig-exclude-modes))
              buffer-file-name


### PR DESCRIPTION
Some buffers get confused if you keep setting their mode, one example
is git-rebase-mode. This is an example buffer of a class of
special-mode buffers which are usually (but not always) non-file
buffers. Either way these buffers are usually special purpose
interactive buffers that will only get confused if editorconfig tries
to mess around with them.