### PR TITLE
Refactoring & add editorconfig-2-mode for beta test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ MAIN_SRC = editorconfig.el
 SRCS = $(wildcard $(PROJECT_ROOT_DIR)/*.el)
 OBJS = $(SRCS:.el=.elc)
 
-$(OBJS): %.elc: %.el
-	$(EMACS) $(BATCHFLAGS) -f batch-byte-compile $^
-
 .PHONY: all clean test test-travis test-ert test-core test-metadata sandbox doc info
 
 all: $(OBJS)
+
+$(OBJS): %.elc: %.el
+	$(EMACS) $(BATCHFLAGS) -f batch-byte-compile $^
 
 clean:
 	-rm -f $(OBJS)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ ones that show up on our radar.
 
 ### <del>File Type (file_type_ext, file_type_emacs)</del>
 
-This feature is currently disabled.  For those who want this functionality,
+File-type feature is currently disabled, because this package is now undergoing
+big internal refactoring.
+For those who want this functionality,
 please consider using [editorconfig-custom-majormode](https://github.com/10sr/editorconfig-custom-majormode-el).
 
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Current Emacs plugin coverage for EditorConfig's [properties][]:
   we just buffer-locally override any preferences that would auto-add them
   to files `.editorconfig` marks as trailing-newline-free
 * `max_line_length`
-* `file_type_ext` (Experimental)
-* `file_type_emacs` (Experimental)
+* <del>`file_type_ext` (Experimental)</del> (See below)
+* <del>`file_type_emacs` (Experimental)</del> (See below)
 * `root` (only used by EditorConfig core)
 
 Not yet covered properties marked with <del>over-strike</del>
@@ -83,21 +83,10 @@ ones that show up on our radar.
 
 
 
-### File Type
+### <del>File Type (file_type_ext, file_type_emacs)</del>
 
-This plugin has experimental supports for `file_type_ext` and
-`file_type_emacs`, which specify "file types" for files.
-As for Emacs, it means `major-mode` can be set.
-
-**file_type_ext** When it is set to `md` for `a.txt`, for example,
-`major-mode` will be decided as if the file name would be `a.txt.md`
-(and thus `markdown-mode` is likely to be used).
-
-**file_type_emacs** When it is set to `markdown` for `a.txt`,
-`markdown-mode`  will be enabled when opening `a.txt`.
-
-These property are experimental and their meanings might change in the
-future updates. When both are specified, `file_type_ext` takes precedence.
+This feature is currently disabled.  For those who want this functionality,
+please consider using [editorconfig-custom-majormode](https://github.com/10sr/editorconfig-custom-majormode-el).
 
 
 ## Customize

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -684,9 +684,11 @@ any of regexps in `editorconfig-exclude-regexps'."
 (defun editorconfig--advice-insert-file-contents (f filename &rest args)
   "Set `coding-system-for-read'.
 This function should be adviced to `insert-file-contents'"
-  (message "editorconfig--acvice-insert-file-contents: %S %S %S"
-           filename args
-           editorconfig--cons-filename-codingsystem)
+  (display-warning '(editorconfig editorconfig--advice-insert-file-contents)
+                   (format ": %S %S %S"
+                           filename args
+                           editorconfig--cons-filename-codingsystem)
+                   :debug)
   (if (and (stringp filename)
            (stringp (car editorconfig--cons-filename-codingsystem))
            (string= (expand-file-name filename)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -583,7 +583,7 @@ It calls `editorconfig-get-properties-from-exec' if
     (require 'editorconfig-core)
     (editorconfig-core-get-properties-hash filename)))
 
-(defun editorconfig-get-properties-call (filename)
+(defun editorconfig-call-get-properties-function (filename)
   "Call `editorconfig-get-properties-function' with FILENAME and return result.
 
 This function also removes 'unset'ted properties and calls
@@ -631,7 +631,7 @@ Use `editorconfig-mode-apply' instead to make use of these variables."
   (when buffer-file-name
     (condition-case err
         (progn
-          (let ((props (editorconfig-get-properties-call buffer-file-name)))
+          (let ((props (editorconfig-call-get-properties-function buffer-file-name)))
             (setq editorconfig-properties-hash props)
             (editorconfig-set-variables props)
             (editorconfig-set-coding-system
@@ -703,7 +703,7 @@ F is this function, and FILENAME and ARGS are arguments passed to F."
             (coding-system nil)
             (ret nil))
         (condition-case err
-            (setq props (editorconfig-get-properties-call filename))
+            (setq props (editorconfig-call-get-properties-function filename))
           (error
            (display-warning 'editorconfig
                             (format "Failed to get properties, styles will not be applied: %S"

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -742,8 +742,6 @@ F is this function, and FILENAME and ARGS are arguments passed to F."
        (display-warning 'editorconfig
                         (format "Error while setting variables from EditorConfig: %S" err))))
     ret))
-;; (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)
-;; (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents)
 
 ;;;###autoload
 (define-minor-mode editorconfig-mode
@@ -766,6 +764,22 @@ To disable EditorConfig in some buffers, modify
     (if editorconfig-mode
         (add-hook hook 'editorconfig-mode-apply)
       (remove-hook hook 'editorconfig-mode-apply))))
+
+(define-minor-mode editorconfig-2-mode
+  "Toggle EditorConfig feature.
+
+This function is provided temporarily for beta testing, and not well tested yet.
+Currently this can cause unexpected behaviors like kill emacs processes and
+destroying your files, so please use with caution if you enable this instead of
+ `editorconfig-mode'."
+  :global t
+  :lighter editorconfig-mode-lighter
+  (if editorconfig-2-mode
+      (progn
+        (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)
+        (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents))
+    (advice-remove 'find-file-noselect 'editorconfig--advice-find-file-noselect)
+    (advice-remove 'insert-file-contents 'editorconfig--advice-insert-file-contents)))
 
 
 ;; Tools

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -730,11 +730,17 @@ F is this function, and FILENAME and ARGS are arguments passed to F."
               (when (and props
                          ;; filename has already been checked
                          (not (editorconfig--disabled-for-majormode major-mode)))
+                (setq editorconfig-properties-hash props)
                 (editorconfig-set-variables props)
-                (run-hook-with-args 'editorconfig-after-apply-functions props)))
+                (condition-case err
+                    (run-hook-with-args 'editorconfig-after-apply-functions props)
+                  (error
+                   (display-warning 'editorconfig
+                                    (format "Error while running `editorconfig-after-apply-functions': %S"
+                                            err))))))
           (error
            (display-warning 'editorconfig
-                            (format "Error: %S" err))))
+                            (format "Error while setting variables from EditorConfig: %S" err))))
         ret)
     (apply f filename args)))
 ;; (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -5,7 +5,7 @@
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; Version: 0.8.1
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
-;; Package-Requires: ((cl-lib "0.5") (emacs "24"))
+;; Package-Requires: ((cl-lib "0.5") (nadvice "0.3") (emacs "24"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
@@ -39,6 +39,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'nadvice)
 (eval-when-compile
   (require 'rx)
   (defvar tex-indent-basic)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -484,8 +484,8 @@ Make a message by passing ARGS to `format-message'."
     (unless (file-readable-p buffer-file-name)
       (set-buffer-file-coding-system coding-system)
       (cl-return-from editorconfig-set-coding-system))
-    (unless (eq coding-system
-                editorconfig--apply-coding-system-currently)
+    (unless (memq coding-system
+                  (coding-system-aliases editorconfig--apply-coding-system-currently))
       ;; Revert functions might call editorconfig-apply again
       (unwind-protect
           (progn
@@ -780,9 +780,13 @@ destroying your files, so please use with caution if you enable this instead of
   (if editorconfig-2-mode
       (progn
         (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)
-        (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents))
+        (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents)
+        (add-hook 'read-only-mode-hook
+                  'editorconfig-mode-apply))
     (advice-remove 'find-file-noselect 'editorconfig--advice-find-file-noselect)
-    (advice-remove 'insert-file-contents 'editorconfig--advice-insert-file-contents)))
+    (advice-remove 'insert-file-contents 'editorconfig--advice-insert-file-contents)
+    (remove-hook 'read-only-mode-hook
+              'editorconfig-mode-apply)))
 
 
 ;; Tools

--- a/ert-tests/editorconfig-2.el
+++ b/ert-tests/editorconfig-2.el
@@ -1,0 +1,123 @@
+(require 'editorconfig)
+
+(defun display-warning (type message &optional level buffer-name)
+  "When testing overwrite this function to throw error when called."
+  (unless (eq level :debug)
+    (error "display-warning called: %S %S %S %S"
+           type
+           message
+           level
+           buffer-name)))
+
+(defmacro with-visit-file (path &rest body)
+  "Visit PATH and evaluate BODY."
+  (declare (indent 1) (debug t))
+  `(let ((buf (find-file-noselect ,path)))
+     (with-current-buffer buf
+       ,@body)
+     (kill-buffer buf)))
+
+;;; interactive
+
+(ert-deftest interactive-test-01 nil
+  "This test should not run on Travis"
+  :tags '(:interactive)
+  (should t))
+
+;;; noninteractive, will run on Travis
+
+(ert-deftest has-feature-01 nil
+  "minimally working - provides 'editorconfig"
+  (should (featurep 'editorconfig)))
+
+(defvar editorconfig-ert-dir
+  (concat default-directory
+          "ert-tests/plugin-tests/test_files/"))
+
+(defvar editorconfig-secondary-ert-dir
+  (concat default-directory
+          "ert-tests/test_files_secondary/"))
+
+(ert-deftest test-editorconfig-2 nil
+  "Check if properties are applied."
+  (editorconfig-2-mode 1)
+
+  (with-visit-file (concat editorconfig-ert-dir
+                           "3_space.txt")
+    (should (eq tab-width 3))
+    (should (eq indent-tabs-mode nil)))
+
+  (with-visit-file (concat editorconfig-ert-dir
+                           "4_space.py")
+    (should (eq python-indent-offset 4))
+    (should (eq tab-width 8))
+    (should (eq indent-tabs-mode nil)))
+  (editorconfig-2-mode -1))
+
+(ert-deftest test-lisp-use-default-indent-2 nil
+  (editorconfig-2-mode 1)
+
+  (with-visit-file (concat editorconfig-secondary-ert-dir
+                           "2_space.el")
+    (should (eq lisp-indent-offset 2)))
+
+  (let ((editorconfig-lisp-use-default-indent t))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                             "2_space.el")
+      (should (eq lisp-indent-offset nil))))
+
+  (let ((editorconfig-lisp-use-default-indent 2))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                             "2_space.el")
+      (should (eq lisp-indent-offset nil))))
+
+  (let ((editorconfig-lisp-use-default-indent 4))
+    (with-visit-file (concat editorconfig-secondary-ert-dir
+                             "2_space.el")
+      (should (eq lisp-indent-offset 2))))
+  (editorconfig-2-mode -1))
+
+(ert-deftest test-trim-trailing-ws-2 nil
+  (editorconfig-2-mode 1)
+  (with-visit-file (concat editorconfig-ert-dir
+                           "trim.txt")
+    (should (memq 'delete-trailing-whitespace
+                  write-file-functions)))
+  (with-visit-file (concat editorconfig-ert-dir
+                           "trim.txt")
+    (read-only-mode 1)
+    (should (not (memq 'delete-trailing-whitespace
+                       write-file-functions))))
+  (editorconfig-2-mode -1))
+
+(ert-deftest test-file-type-emacs-2 nil
+  :expected-result t  ;; Ignore failure
+  (editorconfig-2-mode 1)
+  (with-visit-file (concat editorconfig-secondary-ert-dir
+                           "c.txt")
+    (should (eq major-mode 'conf-unix-mode)))
+  (editorconfig-2-mode -1))
+
+(ert-deftest test-file-type-ext-2 nil
+  :expected-result t  ;; Ignore failure
+  (editorconfig-2-mode 1)
+  (with-visit-file (concat editorconfig-secondary-ert-dir
+                           "a.txt")
+    (should (eq major-mode 'conf-unix-mode)))
+
+  (with-visit-file (concat editorconfig-secondary-ert-dir
+                           "bin/perlscript")
+    (should (eq major-mode 'perl-mode))
+    (should (eq perl-indent-level 5)))
+  (editorconfig-2-mode -1))
+
+(ert-deftest test-hack-properties-functions-2 nil
+  (editorconfig-2-mode 1)
+  (add-hook 'editorconfig-hack-properties-functions
+            (lambda (props)
+              (puthash 'indent_size "5" props)))
+  (with-visit-file (concat editorconfig-ert-dir
+                           "4_space.py")
+    (should (eq python-indent-offset 5)))
+  (setq editorconfig-hack-properties-functions nil)
+  (editorconfig-2-mode -1))

--- a/ert-tests/editorconfig.el
+++ b/ert-tests/editorconfig.el
@@ -90,6 +90,7 @@
   (editorconfig-mode -1))
 
 (ert-deftest test-file-type-emacs nil
+  :expected-result t  ;; Ignore failure
   (editorconfig-mode 1)
   (with-visit-file (concat editorconfig-secondary-ert-dir
                            "c.txt")
@@ -97,6 +98,7 @@
   (editorconfig-mode -1))
 
 (ert-deftest test-file-type-ext nil
+  :expected-result t  ;; Ignore failure
   (editorconfig-mode 1)
   (with-visit-file (concat editorconfig-secondary-ert-dir
                            "a.txt")

--- a/ert-tests/editorconfig.el
+++ b/ert-tests/editorconfig.el
@@ -2,11 +2,12 @@
 
 (defun display-warning (type message &optional level buffer-name)
   "When testing overwrite this function to throw error when called."
-  (error "display-warning called: %S %S %S %S"
-         type
-         message
-         level
-         buffer-name))
+  (unless (eq level :debug)
+    (error "display-warning called: %S %S %S %S"
+           type
+           message
+           level
+           buffer-name)))
 
 (defmacro with-visit-file (path &rest body)
   "Visit PATH and evaluate BODY."


### PR DESCRIPTION
- Refactoring editorconfig-mode
  - Temporarily drop file-type support
- Add editorconfig-2-mode to test a new mechanism of applying properties