### PR TITLE
Fix excluding the recentf-save-file when in a symlinked directory

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -318,7 +318,7 @@ When variable `buffer-file-name' matches any of the regexps, then
 (with-eval-after-load 'recentf
   (add-to-list 'editorconfig-exclude-regexps
                (rx-to-string '(seq string-start
-                                   (eval (expand-file-name recentf-save-file)))
+                                   (eval (file-truename (expand-file-name recentf-save-file))))
                              t)))
 
 (defcustom editorconfig-trim-whitespaces-mode nil


### PR DESCRIPTION
Unfortunately, it seems like the fix in #241 wasn't quite enough - my .emacs.d is symlinked from another folder, and it seems like the recentf-save-file has all symlinks resolved - when quitting emacs I was asked about modifications in the true path, but the recentf-save-file was set to the non-symlink-resolved path.

Grabbing the truename of the file seems to fix this issue for me.