### PR TITLE
Check `buffer-file-name` before applying editorconfig

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -634,7 +634,7 @@ It calls `editorconfig-get-properties-from-exec' if
 `editorconfig-exec-path' is found, otherwise
 `editorconfig-core-get-properties-hash'."
   (if (and (executable-find editorconfig-exec-path)
-           (not (file-remote-p buffer-file-name)))
+           (not (file-remote-p filename)))
       (editorconfig-get-properties-from-exec filename)
     (require 'editorconfig-core)
     (editorconfig-core-get-properties-hash filename)))


### PR DESCRIPTION
Emacs reports the following message when I open a directory in dired if
editorconfig-mode is enabled:

    Warning (editorconfig): Failed to get properties, styles will not be applied: (editorconfig-error "Error from editorconfig-get-properties-function: (wrong-type-argument stringp nil)")

This warning is from `editorconfig--advice-find-file-noselect`, so
`buffer-file-name` should be checked first in this advice.
