### PR TITLE
Enable indentation for tree-sitter based typescript mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -261,6 +261,7 @@ This hook will be run even when there are no matching sections in
               tcl-continued-indent-level)
     (terra-mode terra-indent-level)
     (typescript-mode typescript-indent-level)
+    (typescript-ts-base-mode typescript-ts-mode-indent-offset)
     (verilog-mode verilog-indent-level
                   verilog-indent-level-behavioral
                   verilog-indent-level-declaration


### PR DESCRIPTION
Emacs 29 introduced tree-sitter and tree-sitter major modes for a number of languages (including typescript)
This PR fixes indentation settings for both .ts and .tsx files when using new major modes.

Probably it should fix https://github.com/editorconfig/editorconfig-emacs/issues/268, if Emacs 29 with tree-sitter is used there.
