### PR TITLE
chore: Place emacs dependency to the front

### DIFF
--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-conf-mode.el --- Major mode for editing .editorconfig files  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2011-2021 EditorConfig Team
+;; Copyright (C) 2011-2022 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-core-handle.el --- Handle Class for EditorConfig File  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2011-2021 EditorConfig Team
+;; Copyright (C) 2011-2022 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-core.el --- EditorConfig Core library in Emacs Lisp  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2011-2021 EditorConfig Team
+;; Copyright (C) 2011-2022 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -1,6 +1,6 @@
 ;;; editorconfig-fnmatch.el --- Glob pattern matching in Emacs lisp  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2011-2021 EditorConfig Team
+;; Copyright (C) 2011-2022 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -1,6 +1,6 @@
 ;;; editorconfig.el --- EditorConfig Emacs Plugin  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2011-2021 EditorConfig Team
+;; Copyright (C) 2011-2022 EditorConfig Team
 
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; Version: 0.9.1

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -5,7 +5,7 @@
 ;; Author: EditorConfig Team <editorconfig@googlegroups.com>
 ;; Version: 0.9.1
 ;; URL: https://github.com/editorconfig/editorconfig-emacs#readme
-;; Package-Requires: ((cl-lib "0.5") (nadvice "0.3") (emacs "24"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (nadvice "0.3"))
 
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors


### PR DESCRIPTION
minor changes.

1. I prefer to place `emacs` dependency to the front. That's what most Elisp users would want to see first before using a package
2. Update copyright year

---

I saw this package supports very old versions of Emacs, is there any plan to upgrade the code base so it only supports more modern Emacs versions, maybe drop `24.x` and `25.x`? 😅 

cc @10sr @xuhdev 