### PR TITLE
Drop Emacs 24.x and 25.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,5 +54,10 @@ jobs:
         with:
           version: 'snapshot'
 
-      - name: Run tests
-        run: make check
+      - name: Run tests (Unix)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        run: make check-unix
+
+      - name: Run tests (Windows)
+        if: matrix.os == 'windows-latest'
+        run: make check-dos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,3 @@
----
 name: build
 
 on:
@@ -12,30 +11,47 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         emacs_version:
-          - "24.5"
-          - "25.3"
           - "26.3"
           - "27.2"
           - "28.2"
         experimental: [false]
         include:
-          - emacs_version: snapshot
+          - os: ubuntu-latest
+            emacs_version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs_version: snapshot
+            experimental: true
+          - os: windows-latest
+            emacs_version: snapshot
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Setup Emacs
-        uses: purcell/setup-emacs@master
+        uses: jcs090218/setup-emacs@master
         with:
           version: ${{ matrix.emacs_version }}
+
+      - uses: emacs-eask/setup-eask@master
+        with:
+          version: 'snapshot'
+
       - name: Run tests
         run: make check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs_version:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@
 \#*
 .\#*
 *.autosave
+
+# eask packages
+.eask/
+dist/
+
+# packaging
+*-autoloads.el
+*-pkg.el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop Emacs 24.x and 25.x ([#286])
+
 ### Deprecated
 
 ### Removed
@@ -270,6 +272,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3]: https://github.com/editorconfig/editorconfig-emacs/compare/v0.2...v0.3
 [0.2]: https://github.com/editorconfig/editorconfig-emacs/compare/v0.1...v0.2
 [0.1]: https://github.com/editorconfig/editorconfig-emacs/releases/tag/v0.1
+[#286]: https://github.com/editorconfig/editorconfig-emacs/issues/286
 [#280]: https://github.com/editorconfig/editorconfig-emacs/issues/280
 [#263]: https://github.com/editorconfig/editorconfig-emacs/issues/263
 [#260]: https://github.com/editorconfig/editorconfig-emacs/issues/260

--- a/Eask
+++ b/Eask
@@ -1,0 +1,20 @@
+(package "editorconfig"
+         "0.9.1"
+         "EditorConfig Emacs Plugin")
+
+(website-url "https://github.com/editorconfig/editorconfig-emacs#readme")
+(keywords "convenience" "editorconfig")
+
+(package-file "editorconfig.el")
+
+(files "editorconfig-*.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "26.1")
+(depends-on "nadvice")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,20 @@ MAIN_SRC = editorconfig.el
 SRCS = $(wildcard $(PROJECT_ROOT_DIR)/*.el)
 OBJS = $(SRCS:.el=.elc)
 
-.PHONY: check \
+.PHONY: check-unix check-dos \
 	compile clean \
 	test test-ert test-core \
 	sandbox doc
 
 # CI entry
-check: compile test
+check-unix: package install compile test
+check-dos: package install compile test-ert
 
+package:
+	$(EASK) package
+
+install:
+	$(EASK) install
 
 compile:
 	$(EASK) compile

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 TEXI_CHAPTER := EditorConfig Emacs Plugin
 
 EMACS = emacs
+EASK = eask
 PANDOC = pandoc
 AWK = awk
 
@@ -21,16 +22,15 @@ OBJS = $(SRCS:.el=.elc)
 	test test-ert test-core \
 	sandbox doc
 
+# CI entry
 check: compile test
 
 
-compile: $(OBJS)
-
-$(OBJS): %.elc: %.el
-	$(EMACS) $(BATCHFLAGS) -f batch-byte-compile $^
+compile:
+	$(EASK) compile
 
 clean:
-	-rm -f $(OBJS)
+	$(EASK) clean elc
 
 
 doc: doc/editorconfig.texi

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -2,6 +2,8 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
+;; Author: EditorConfig Team <editorconfig@googlegroups.com>
+
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.

--- a/editorconfig-conf-mode.el
+++ b/editorconfig-conf-mode.el
@@ -2,8 +2,6 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
-;; Author: EditorConfig Team <editorconfig@googlegroups.com>
-
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.
@@ -77,25 +75,19 @@
 
     ;; Highlight all key values
     (dolist (key-value key-value-list)
-      (push
-       `(,(format "[=:][ \t]*\\(%s\\)\\([ \t]\\|$\\)" key-value)
-         1 font-lock-constant-face)
-       font-lock-value
-       ))
+      (push `(,(format "[=:][ \t]*\\(%s\\)\\([ \t]\\|$\\)" key-value)
+              1 font-lock-constant-face)
+            font-lock-value))
     ;; Highlight all key properties
     (dolist (key-property key-property-list)
-      (push
-       `(,(format "^[ \t]*\\(%s\\)[ \t]*[=:]" key-property)
-         1 font-lock-builtin-face)
-       font-lock-value
-       ))
+      (push `(,(format "^[ \t]*\\(%s\\)[ \t]*[=:]" key-property)
+              1 font-lock-builtin-face)
+            font-lock-value))
 
     (conf-mode-initialize "#" font-lock-value)))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             '("\\.editorconfig\\'" . editorconfig-conf-mode))
+(add-to-list 'auto-mode-alist '("\\.editorconfig\\'" . editorconfig-conf-mode))
 
 (provide 'editorconfig-conf-mode)
-
 ;;; editorconfig-conf-mode.el ends here

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -2,8 +2,6 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
-;; Author: EditorConfig Team <editorconfig@googlegroups.com>
-
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.
@@ -57,9 +55,7 @@ Slots:
 DIR should be the directory where .editorconfig file which has SECTION lives.
 IF not match, return nil."
   (when (editorconfig-core-handle--fnmatch-p
-         file
-         (editorconfig-core-handle-section-name section)
-         dir)
+         file (editorconfig-core-handle-section-name section) dir)
     (editorconfig-core-handle-section-props section)))
 
 (cl-defstruct editorconfig-core-handle
@@ -89,13 +85,10 @@ Slots:
 
 If CONF does not exist return nil."
   (when (file-readable-p conf)
-    (let ((cached (gethash conf
-                           editorconfig-core-handle--cache-hash))
-          (mtime (nth 5
-                      (file-attributes conf))))
+    (let ((cached (gethash conf editorconfig-core-handle--cache-hash))
+          (mtime (nth 5 (file-attributes conf))))
       (if (and cached
-               (equal (editorconfig-core-handle-mtime cached)
-                      mtime))
+               (equal (editorconfig-core-handle-mtime cached) mtime))
           cached
         (let ((parsed (editorconfig-core-handle--parse-file conf)))
           (puthash conf
@@ -151,16 +144,10 @@ If pattern has slash, pattern should be relative to DIR.
 
 This function is a fnmatch with a few modification for EditorConfig usage."
   (if (string-match-p "/" pattern)
-      (let ((pattern (replace-regexp-in-string "^/"
-                                               ""
-                                               pattern))
+      (let ((pattern (replace-regexp-in-string "^/" "" pattern))
             (dir (file-name-as-directory dir)))
-        (editorconfig-fnmatch-p name
-                                (concat dir
-                                        pattern)))
-    (editorconfig-fnmatch-p name
-                            (concat "**/"
-                                    pattern))))
+        (editorconfig-fnmatch-p name (concat dir pattern)))
+    (editorconfig-fnmatch-p name (concat "**/" pattern))))
 
 (defsubst editorconfig-core-handle--string-trim (str)
   "Remove leading and trailing whitespaces from STR."
@@ -196,8 +183,7 @@ If CONF is not found return nil."
             (props ())
 
             ;; Current line num
-            (current-line-number 1)
-            )
+            (current-line-number 1))
         (while (not (eq (point) point-max))
           (setq line
                 (buffer-substring-no-properties (line-beginning-position)
@@ -224,21 +210,14 @@ If CONF is not found return nil."
             (setq pattern (match-string 1 line)))
 
            (t
-            (let ((idx (string-match "=\\|:"
-                                     line)))
+            (let ((idx (string-match "=\\|:" line)))
               (unless idx
                 (error "Error while reading config file: %s:%d:\n    %s\n"
-                       conf
-                       current-line-number
-                       line))
-              (let (
-                    (key (downcase (editorconfig-core-handle--string-trim
-                                    (substring line
-                                               0
-                                               idx))))
+                       conf current-line-number line))
+              (let ((key (downcase (editorconfig-core-handle--string-trim
+                                    (substring line 0 idx))))
                     (value (editorconfig-core-handle--string-trim
-                            (substring line
-                                       (1+ idx)))))
+                            (substring line (1+ idx)))))
                 (when (and (< (length key) 51)
                            (< (length value) 256))
                   (if pattern
@@ -246,13 +225,10 @@ If CONF is not found return nil."
                         (setq props
                               `(,@props (,key . ,value))))
                     (setq top-props
-                          `(,@top-props (,key . ,value))))))))
-           )
-          (setq current-line-number
-                (1+ current-line-number))
+                          `(,@top-props (,key . ,value)))))))))
+          (setq current-line-number (1+ current-line-number))
           (goto-char (point-min))
-          (forward-line (1- current-line-number))
-          )
+          (forward-line (1- current-line-number)))
         (when pattern
           (setq sections
                 `(,@sections ,(make-editorconfig-core-handle-section
@@ -262,5 +238,4 @@ If CONF is not found return nil."
               :sections sections)))))
 
 (provide 'editorconfig-core-handle)
-
 ;;; editorconfig-core-handle.el ends here

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -2,6 +2,8 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
+;; Author: EditorConfig Team <editorconfig@googlegroups.com>
+
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -2,8 +2,6 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
-;; Author: EditorConfig Team <editorconfig@googlegroups.com>
-
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.
@@ -80,24 +78,20 @@ RESULT is used internally and normally should not be used."
   (let ((handle (editorconfig-core-handle (concat (file-name-as-directory dir)
                                                   confname)))
         (parent (file-name-directory (directory-file-name dir))))
-    (if (or (string= parent
-                     dir)
-            (and handle
-                 (editorconfig-core-handle-root-p handle)))
-        (cl-remove-if-not 'identity
-                          (cons handle result))
+    (if (or (string= parent dir)
+            (and handle (editorconfig-core-handle-root-p handle)))
+        (cl-remove-if-not 'identity (cons handle result))
       (editorconfig-core--get-handles parent
                                       confname
-                                      (cons handle
-                                            result)))))
+                                      (cons handle result)))))
 
 ;;;###autoload
 (defun editorconfig-core-get-nearest-editorconfig (directory)
   "Return path to .editorconfig file that is closest to DIRECTORY."
-  (let ((handle (car (last (editorconfig-core--get-handles directory
+  (when-let ((handle (car (last
+                           (editorconfig-core--get-handles directory
                                                            ".editorconfig")))))
-    (when handle
-      (editorconfig-core-handle-path handle))))
+    (editorconfig-core-handle-path handle)))
 
 ;;;###autoload
 (defun editorconfig-core-get-properties (&optional file confname confversion)
@@ -111,9 +105,7 @@ This functions returns alist of properties.  Each element will look like
   (let ((hash (editorconfig-core-get-properties-hash file confname confversion))
         (result nil))
     (maphash (lambda (key value)
-               (add-to-list 'result
-                            (cons (symbol-name key)
-                                  value)))
+               (add-to-list 'result (cons (symbol-name key) value)))
              hash)
     result))
 
@@ -122,11 +114,7 @@ This functions returns alist of properties.  Each element will look like
 
 This is a destructive function, hash INTO will be modified.
 When the same key exists in both two hashes, values of UPDATE takes precedence."
-  (maphash (lambda (key value)
-             (puthash key
-                      value
-                      into))
-           update)
+  (maphash (lambda (key value) (puthash key value into)) update)
   into)
 
 ;;;###autoload
@@ -142,10 +130,8 @@ hash object instead."
         (expand-file-name (or file
                               buffer-file-name
                               (error "FILE is not given and `buffer-file-name' is nil"))))
-  (setq confname (or confname
-                     ".editorconfig"))
-  (setq confversion (or confversion
-                        "0.12.0"))
+  (setq confname (or confname ".editorconfig"))
+  (setq confversion (or confversion "0.12.0"))
   (let ((result (make-hash-table)))
     (dolist (handle (editorconfig-core--get-handles (file-name-directory file)
                                                     confname))
@@ -154,16 +140,10 @@ hash object instead."
                                                                                    file)))
 
     ;; Downcase known boolean values
-    (dolist (key '(
-                   end_of_line indent_style indent_size insert_final_newline
-                   trim_trailing_whitespace charset
-                   ))
-      (let ((val (gethash key
-                          result)))
-        (when val
-          (puthash key
-                   (downcase val)
-                   result))))
+    (dolist (key '( end_of_line indent_style indent_size insert_final_newline
+                    trim_trailing_whitespace charset))
+      (when-let ((val (gethash key result)))
+        (puthash key (downcase val) result)))
 
     ;; Add indent_size property
     (let ((v-indent-size (gethash 'indent_size result))
@@ -182,21 +162,16 @@ hash object instead."
       (when (and v-indent-size
                  (not v-tab-width)
                  (not (string= v-indent-size "tab")))
-        (puthash 'tab_width
-                 v-indent-size
-                 result)))
+        (puthash 'tab_width v-indent-size result)))
     ;; Update indent-size property
     (let ((v-indent-size (gethash 'indent_size result))
           (v-tab-width (gethash 'tab_width result)))
       (when (and v-indent-size
                  v-tab-width
                  (string= v-indent-size "tab"))
-        (puthash 'indent_size
-                 v-tab-width
-                 result)))
+        (puthash 'indent_size v-tab-width result)))
 
     result))
 
 (provide 'editorconfig-core)
-
 ;;; editorconfig-core.el ends here

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -2,6 +2,8 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
+;; Author: EditorConfig Team <editorconfig@googlegroups.com>
+
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -2,6 +2,8 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
+;; Author: EditorConfig Team <editorconfig@googlegroups.com>
+
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.

--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -2,8 +2,6 @@
 
 ;; Copyright (C) 2011-2022 EditorConfig Team
 
-;; Author: EditorConfig Team <editorconfig@googlegroups.com>
-
 ;; See
 ;; https://github.com/editorconfig/editorconfig-emacs/graphs/contributors
 ;; or the CONTRIBUTORS file for the list of contributors.
@@ -213,12 +211,10 @@ translation is found for PATTERN."
            (setq pos index
                  has-comma nil)
            (while (and (or (and (< pos length)
-                                (not (= (aref pattern pos)
-                                        ?})))
+                                (not (= (aref pattern pos) ?})))
                            is-escaped)
                        (not has-comma))
-             (if (and (eq (aref pattern pos)
-                          ?,)
+             (if (and (eq (aref pattern pos) ?,)
                       (not is-escaped))
                  (setq has-comma t)
                (setq is-escaped (and (eq (aref pattern pos)
@@ -242,8 +238,7 @@ translation is found for PATTERN."
                                                                    "\\|")
                                                         "\\)"))))
                    (let ((inner (editorconfig-fnmatch--do-translate pattern-sub t)))
-                     (setq result `(,@result ,(format "{%s}"
-                                                      inner)))))
+                     (setq result `(,@result ,(format "{%s}" inner)))))
                  (setq index (1+ pos)))
              (if matching-braces
                  (setq result `(,@result "\\(?:")
@@ -264,17 +259,14 @@ translation is found for PATTERN."
              (setq result `(,@result "}"))))
 
           (?/
-           (if (and (<= (+ index 3)
-                        (length pattern))
-                    (string= (substring pattern index (+ index 3))
-                             "**/"))
+           (if (and (<= (+ index 3) (length pattern))
+                    (string= (substring pattern index (+ index 3)) "**/"))
                (setq result `(,@result "\\(?:/\\|/.*/\\)")
                      index (+ index 3))
              (setq result `(,@result "/"))))
 
           (t
-           (unless (= current-char
-                      ?\\)
+           (unless (= current-char ?\\)
              (setq result `(,@result ,(regexp-quote (char-to-string current-char)))))))
 
         (if (= current-char ?\\)
@@ -284,8 +276,7 @@ translation is found for PATTERN."
           (setq is-escaped nil))))
     (unless nested
       (setq result `("^" ,@result "\\'")))
-    (apply 'concat result)))
+    (apply #'concat result)))
 
 (provide 'editorconfig-fnmatch)
-
 ;;; editorconfig-fnmatch.el ends here

--- a/ert-tests/editorconfig-core-handle.el
+++ b/ert-tests/editorconfig-core-handle.el
@@ -1,14 +1,38 @@
+;;; editorconfig-core-handle.el --- Tests editorconfig-core-handle  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2011-2022 EditorConfig Team
+
+;; This file is part of EditorConfig Emacs Plugin.
+
+;; EditorConfig Emacs Plugin is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at your
+;; option) any later version.
+
+;; EditorConfig Emacs Plugin is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+;; Public License for more details.
+
+;; You should have received a copy of the GNU General Public License along with
+;; EditorConfig Emacs Plugin. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests editorconfig-core-handle
+
+;;; Code:
+
 (require 'editorconfig-core-handle)
 
-(defconst fixtures (concat (file-name-directory load-file-name)
-                           "fixtures/"))
+(defconst fixtures (concat (file-name-directory load-file-name) "fixtures/")
+  "Path to fixtures.")
 
 (set-variable 'vc-handled-backends nil)
 
 (ert-deftest test-editorconfig-core-handle ()
   ;; handle.ini
-  (let* ((conf (concat fixtures
-                       "handle.ini"))
+  (let* ((conf (concat fixtures "handle.ini"))
          (handle (editorconfig-core-handle conf)))
     (should (editorconfig-core-handle-root-p handle))
     (should (equal (editorconfig-core-handle-get-properties handle
@@ -20,8 +44,7 @@
                                                                     "a.js"))
                    '((("key1" . "value1")) (("key2" . "value2"))))))
   ;; Test twice for checking cache
-  (let* ((conf (concat fixtures
-                       "handle.ini"))
+  (let* ((conf (concat fixtures "handle.ini"))
          (handle (editorconfig-core-handle conf)))
     (should (editorconfig-core-handle-root-p handle))
     (should (equal (editorconfig-core-handle-get-properties handle
@@ -34,8 +57,7 @@
                    '((("key1" . "value1")) (("key2" . "value2"))))))
 
   ;; handle2.ini
-  (let* ((conf (concat fixtures
-                       "handle2.ini"))
+  (let* ((conf (concat fixtures "handle2.ini"))
          (handle (editorconfig-core-handle conf)))
     (should-not (editorconfig-core-handle-root-p handle))
     (should (equal (editorconfig-core-handle-get-properties handle
@@ -53,3 +75,5 @@
          (handle (editorconfig-core-handle conf)))
     (should (editorconfig-core-handle-p handle)))
   )
+
+;;; editorconfig-core-handle.el ends here

--- a/ert-tests/editorconfig-core.el
+++ b/ert-tests/editorconfig-core.el
@@ -1,16 +1,39 @@
+;;; editorconfig-core.el --- Tests editorconfig-core  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2011-2022 EditorConfig Team
+
+;; This file is part of EditorConfig Emacs Plugin.
+
+;; EditorConfig Emacs Plugin is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at your
+;; option) any later version.
+
+;; EditorConfig Emacs Plugin is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+;; Public License for more details.
+
+;; You should have received a copy of the GNU General Public License along with
+;; EditorConfig Emacs Plugin. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests editorconfig-core
+
+;;; Code:
+
 (require 'editorconfig-core)
 
 (set-variable 'vc-handled-backends nil)
 
 (ert-deftest test-editorconfig-core--get-handles ()
-  (let* ((fixtures (concat default-directory
-                           "/ert-tests/fixtures/"))
-         (dir (concat fixtures
-                      "dir1"))
+  (let* ((fixtures (concat default-directory "/ert-tests/fixtures/"))
+         (dir (concat fixtures "dir1"))
          (confname "parent.ini")
-         (handles (editorconfig-core--get-handles dir
-                                                  confname)))
-    (should (= 2
-               (length handles)))
+         (handles (editorconfig-core--get-handles dir confname)))
+    (should (= 2 (length handles)))
     (should (editorconfig-core-handle-p (car handles)))
     (should (editorconfig-core-handle-p (cadr handles)))))
+
+;;; editorconfig-core.el ends here

--- a/ert-tests/editorconfig-fnmatch.el
+++ b/ert-tests/editorconfig-fnmatch.el
@@ -1,3 +1,28 @@
+;;; editorconfig-fnmatch.el --- Tests editorconfig-fnmatch  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2011-2022 EditorConfig Team
+
+;; This file is part of EditorConfig Emacs Plugin.
+
+;; EditorConfig Emacs Plugin is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at your
+;; option) any later version.
+
+;; EditorConfig Emacs Plugin is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+;; Public License for more details.
+
+;; You should have received a copy of the GNU General Public License along with
+;; EditorConfig Emacs Plugin. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests editorconfig-fnmatch
+
+;;; Code:
+
 (require 'editorconfig-fnmatch)
 
 (set-variable 'vc-handled-backends nil)
@@ -103,8 +128,7 @@
            ("-1.js" "{3..-3}.js")
            )))
     (dolist (args cases-t)
-      (message "-> t: %S"
-               `(editorconfig-fnmatch-p ,@args))
+      (message "-> t: %S" `(editorconfig-fnmatch-p ,@args))
       (message "   Elapsed: %S"
                (car (benchmark-run 3 (should (apply 'editorconfig-fnmatch-p
                                                     args))))))
@@ -115,3 +139,5 @@
                (car (benchmark-run 3 (should-not (apply 'editorconfig-fnmatch-p
                                                         args)))))))
   )
+
+;;; editorconfig-fnmatch.el ends here

--- a/ert-tests/editorconfig.el
+++ b/ert-tests/editorconfig.el
@@ -1,3 +1,28 @@
+;;; editorconfig.el --- Tests editorconfig  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2011-2022 EditorConfig Team
+
+;; This file is part of EditorConfig Emacs Plugin.
+
+;; EditorConfig Emacs Plugin is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at your
+;; option) any later version.
+
+;; EditorConfig Emacs Plugin is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+;; Public License for more details.
+
+;; You should have received a copy of the GNU General Public License along with
+;; EditorConfig Emacs Plugin. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests editorconfig
+
+;;; Code:
+
 (require 'editorconfig)
 
 (set-variable 'vc-handled-backends nil)
@@ -16,8 +41,7 @@
   (declare (indent 1) (debug t))
   `(let ((buf (find-file-noselect ,path)))
      (unwind-protect
-         (with-current-buffer buf
-           ,@body)
+         (with-current-buffer buf ,@body)
        (kill-buffer buf))))
 
 ;;; interactive
@@ -34,24 +58,20 @@
   (should (featurep 'editorconfig)))
 
 (defvar editorconfig-ert-dir
-  (concat default-directory
-          "ert-tests/plugin-tests/test_files/"))
+  (concat default-directory "ert-tests/plugin-tests/test_files/"))
 
 (defvar editorconfig-secondary-ert-dir
-  (concat default-directory
-          "ert-tests/test_files_secondary/"))
+  (concat default-directory "ert-tests/test_files_secondary/"))
 
 (ert-deftest test-editorconfig nil
   "Check if properties are applied."
   (editorconfig-mode 1)
 
-  (with-visit-file (concat editorconfig-ert-dir
-                           "3_space.txt")
+  (with-visit-file (concat editorconfig-ert-dir "3_space.txt")
     (should (eq tab-width 3))
     (should (eq indent-tabs-mode nil)))
 
-  (with-visit-file (concat editorconfig-ert-dir
-                           "4_space.py")
+  (with-visit-file (concat editorconfig-ert-dir "4_space.py")
     (should (eq python-indent-offset 4))
     (should (eq tab-width 8))
     (should (eq indent-tabs-mode nil)))
@@ -60,34 +80,28 @@
 (ert-deftest test-lisp-use-default-indent nil
   (editorconfig-mode 1)
 
-  (with-visit-file (concat editorconfig-secondary-ert-dir
-                           "2_space.el")
+  (with-visit-file (concat editorconfig-secondary-ert-dir "2_space.el")
     (should (eq lisp-indent-offset 2)))
 
   (let ((editorconfig-lisp-use-default-indent t))
-    (with-visit-file (concat editorconfig-secondary-ert-dir
-                             "2_space.el")
+    (with-visit-file (concat editorconfig-secondary-ert-dir "2_space.el")
       (should (eq lisp-indent-offset nil))))
 
   (let ((editorconfig-lisp-use-default-indent 2))
-    (with-visit-file (concat editorconfig-secondary-ert-dir
-                             "2_space.el")
+    (with-visit-file (concat editorconfig-secondary-ert-dir "2_space.el")
       (should (eq lisp-indent-offset nil))))
 
   (let ((editorconfig-lisp-use-default-indent 4))
-    (with-visit-file (concat editorconfig-secondary-ert-dir
-                             "2_space.el")
+    (with-visit-file (concat editorconfig-secondary-ert-dir "2_space.el")
       (should (eq lisp-indent-offset 2))))
   (editorconfig-mode -1))
 
 (ert-deftest test-trim-trailing-ws nil
   (editorconfig-mode 1)
-  (with-visit-file (concat editorconfig-ert-dir
-                           "trim.txt")
+  (with-visit-file (concat editorconfig-ert-dir "trim.txt")
     (should (memq 'delete-trailing-whitespace
                   write-file-functions)))
-  (with-visit-file (concat editorconfig-ert-dir
-                           "trim.txt")
+  (with-visit-file (concat editorconfig-ert-dir "trim.txt")
     (read-only-mode 1)
     (should (not (memq 'delete-trailing-whitespace
                        write-file-functions))))
@@ -96,20 +110,17 @@
 (ert-deftest test-file-type-emacs nil
   :expected-result t  ;; Ignore failure
   (editorconfig-mode 1)
-  (with-visit-file (concat editorconfig-secondary-ert-dir
-                           "c.txt")
+  (with-visit-file (concat editorconfig-secondary-ert-dir "c.txt")
     (should (eq major-mode 'conf-unix-mode)))
   (editorconfig-mode -1))
 
 (ert-deftest test-file-type-ext nil
   :expected-result t  ;; Ignore failure
   (editorconfig-mode 1)
-  (with-visit-file (concat editorconfig-secondary-ert-dir
-                           "a.txt")
+  (with-visit-file (concat editorconfig-secondary-ert-dir "a.txt")
     (should (eq major-mode 'conf-unix-mode)))
 
-  (with-visit-file (concat editorconfig-secondary-ert-dir
-                           "bin/perlscript")
+  (with-visit-file (concat editorconfig-secondary-ert-dir "bin/perlscript")
     (should (eq major-mode 'perl-mode))
     (should (eq perl-indent-level 5)))
   (editorconfig-mode -1))
@@ -119,8 +130,9 @@
   (add-hook 'editorconfig-hack-properties-functions
             (lambda (props)
               (puthash 'indent_size "5" props)))
-  (with-visit-file (concat editorconfig-ert-dir
-                           "4_space.py")
+  (with-visit-file (concat editorconfig-ert-dir "4_space.py")
     (should (eq python-indent-offset 5)))
   (setq editorconfig-hack-properties-functions nil)
   (editorconfig-mode -1))
+
+;;; editorconfig.el ends here

--- a/ert-tests/metadata.el
+++ b/ert-tests/metadata.el
@@ -1,3 +1,28 @@
+;;; metadata.el --- Metadata before ert-tests  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2011-2022 EditorConfig Team
+
+;; This file is part of EditorConfig Emacs Plugin.
+
+;; EditorConfig Emacs Plugin is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or (at your
+;; option) any later version.
+
+;; EditorConfig Emacs Plugin is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+;; Public License for more details.
+
+;; You should have received a copy of the GNU General Public License along with
+;; EditorConfig Emacs Plugin. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Metadata before ert-tests
+
+;;; Code:
+
 (require 'package)
 
 (set-variable 'vc-handled-backends nil)
@@ -6,9 +31,9 @@
 
 (ert-deftest test-metadata ()
   (dolist (el metadata-el-files)
-    (message "Loading info: %s"
-             el)
+    (message "Loading info: %s" el)
     (with-temp-buffer
       (insert-file-contents el)
-      (message "%S"
-               (package-buffer-info)))))
+      (message "%S" (package-buffer-info)))))
+
+;;; metadata.el ends here


### PR DESCRIPTION
As discussed in #285, this patch has no feature changes, only upgrading the codebase and style changes. I also added the CI for `macOS`  and `Windows`.

I've done the CI in my fork, see the result in https://github.com/jcs-PR/editorconfig-emacs/actions/runs/3794760896.