### PR TITLE
Add `js-ts-mode' spec to `editorconfig-indentation-alist'

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -234,6 +234,7 @@ This hook will be run even when there are no matching sections in
     (java-ts-mode c-basic-offset
                   java-ts-mode-indent-offset)
     (js-mode js-indent-level)
+    (js-ts-mode js-indent-level)
     (js-jsx-mode js-indent-level sgml-basic-offset)
     (js2-mode js2-basic-offset)
     (js2-jsx-mode js2-basic-offset sgml-basic-offset)


### PR DESCRIPTION
Hi maintainer:

`editorconfig-emacs` missing the emacs-29's `js-ts-mode` indentation specification which I've made for this pull request.

Thanks.