### PR TITLE
fix write-file-functions default value

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -569,7 +569,7 @@ to non-nil when FINAL-NEWLINE is true."
     (when editorconfig-trim-whitespaces-mode
       (funcall editorconfig-trim-whitespaces-mode 0))
     (setq write-file-functions
-          (delete 'delete-trailing-whitespace write-file-functions))))
+          (remove 'delete-trailing-whitespace write-file-functions))))
 
 (defun editorconfig-set-line-length (length)
   "Set the max line length (`fill-column') to LENGTH."


### PR DESCRIPTION
`delete` deletion is performed destructively here, use `remove` to avoid changing global `write-file-functions` value.