### PR TITLE
fix: Fix compile warnings

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -50,7 +50,8 @@
   (defvar tex-indent-basic)
   (defvar tex-indent-item)
   (defvar tex-indent-arg)
-  (defvar evil-shift-width))
+  (defvar evil-shift-width)
+  (defvar python-indent-offset))
 
 (require 'editorconfig-core)
 


### PR DESCRIPTION
Fix compile warning https://github.com/editorconfig/editorconfig-emacs/actions/runs/4655590115/jobs/8238372696#step:5:66

```
In editorconfig-set-indentation-python-mode:
editorconfig.el:414:36:Warning: assignment to free variable
    ‘python-indent-offset’
```