### PR TITLE
Load subr-x when compiling

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -47,6 +47,7 @@
 
 (eval-when-compile
   (require 'rx)
+  (require 'subr-x)
   (defvar tex-indent-basic)
   (defvar tex-indent-item)
   (defvar tex-indent-arg)


### PR DESCRIPTION
`when-let` depends on this.

Fixes #289 