### PR TITLE
Remove editorconfig-mode legacy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove editorconfig-mode legacy version ([#304])
+  - Remove flag `editorconfig--legacy-version`, which was defined in [#263]
+
 ### Deprecated
 
 ### Removed
@@ -303,6 +306,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3]: https://github.com/editorconfig/editorconfig-emacs/compare/v0.2...v0.3
 [0.2]: https://github.com/editorconfig/editorconfig-emacs/compare/v0.1...v0.2
 [0.1]: https://github.com/editorconfig/editorconfig-emacs/releases/tag/v0.1
+[#304]: https://github.com/editorconfig/editorconfig-emacs/issues/304
 [#306]: https://github.com/editorconfig/editorconfig-emacs/issues/306
 [#305]: https://github.com/editorconfig/editorconfig-emacs/issues/305
 [#302]: https://github.com/editorconfig/editorconfig-emacs/issues/302

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -861,11 +861,6 @@ F is that function, and FILENAME and ARGS are arguments passed to F."
                         (format "Error while setting variables from EditorConfig: %S" err))))
     ret))
 
-(defvar editorconfig--legacy-version nil
-  "Use legacy version of editorconfig-mode.
-
-As of 2021/08/30, `editorconfig-mode' uses totally new implementation by
-default.  This flag disables this and go back to previous version.")
 
 ;;;###autoload
 (define-minor-mode editorconfig-mode
@@ -875,41 +870,26 @@ To disable EditorConfig in some buffers, modify
 `editorconfig-exclude-modes' or `editorconfig-exclude-regexps'."
   :global t
   :lighter editorconfig-mode-lighter
-  (if (not editorconfig--legacy-version)
-      (let ((modehooks '(prog-mode-hook
-                         text-mode-hook
-                         read-only-mode-hook
-                         ;; Some modes call `kill-all-local-variables' in their init
-                         ;; code, which clears some values set by editorconfig.
-                         ;; For those modes, editorconfig-apply need to be called
-                         ;; explicitly through their hooks.
-                         rpm-spec-mode-hook)))
-        (if editorconfig-mode
-            (progn
-              (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)
-              (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents)
-              (dolist (hook modehooks)
-                (add-hook hook
-                          'editorconfig-major-mode-hook
-                          t)))
-          (advice-remove 'find-file-noselect 'editorconfig--advice-find-file-noselect)
-          (advice-remove 'insert-file-contents 'editorconfig--advice-insert-file-contents)
+  (let ((modehooks '(prog-mode-hook
+                     text-mode-hook
+                     read-only-mode-hook
+                     ;; Some modes call `kill-all-local-variables' in their init
+                     ;; code, which clears some values set by editorconfig.
+                     ;; For those modes, editorconfig-apply need to be called
+                     ;; explicitly through their hooks.
+                     rpm-spec-mode-hook)))
+    (if editorconfig-mode
+        (progn
+          (advice-add 'find-file-noselect :around 'editorconfig--advice-find-file-noselect)
+          (advice-add 'insert-file-contents :around 'editorconfig--advice-insert-file-contents)
           (dolist (hook modehooks)
-            (remove-hook hook 'editorconfig-major-mode-hook))))
-
-    ;; editorconfig--legacy-version is enabled
-    ;; See https://github.com/editorconfig/editorconfig-emacs/issues/141 for why
-    ;; not `after-change-major-mode-hook'
-    (dolist (hook '(change-major-mode-after-body-hook
-                    read-only-mode-hook
-                    ;; Some modes call `kill-all-local-variables' in their init
-                    ;; code, which clears some values set by editorconfig.
-                    ;; For those modes, editorconfig-apply need to be called
-                    ;; explicitly through their hooks.
-                    rpm-spec-mode-hook))
-      (if editorconfig-mode
-          (add-hook hook 'editorconfig-mode-apply)
-        (remove-hook hook 'editorconfig-mode-apply)))))
+            (add-hook hook
+                      'editorconfig-major-mode-hook
+                      t)))
+      (advice-remove 'find-file-noselect 'editorconfig--advice-find-file-noselect)
+      (advice-remove 'insert-file-contents 'editorconfig--advice-insert-file-contents)
+      (dolist (hook modehooks)
+        (remove-hook hook 'editorconfig-major-mode-hook)))))
 
 
 ;; Tools


### PR DESCRIPTION
There seems to be no bug caused by using the new version, so removing the switch to use the legacy implenentation 🙌 