### PR TITLE
Fix when-let (again)

### DIFF
--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -93,7 +93,7 @@ RESULT is used internally and normally should not be used."
 ;;;###autoload
 (defun editorconfig-core-get-nearest-editorconfig (directory)
   "Return path to .editorconfig file that is closest to DIRECTORY."
-  (when-let ((handle (car (last
+  (when-let* ((handle (car (last
                            (editorconfig-core--get-handles directory
                                                            ".editorconfig")))))
     (editorconfig-core-handle-path handle)))
@@ -147,7 +147,7 @@ hash object instead."
     ;; Downcase known boolean values
     (dolist (key '( end_of_line indent_style indent_size insert_final_newline
                     trim_trailing_whitespace charset))
-      (when-let ((val (gethash key result)))
+      (when-let* ((val (gethash key result)))
         (puthash key (downcase val) result)))
 
     ;; Add indent_size property

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -68,6 +68,9 @@
 
 (require 'editorconfig-core-handle)
 
+(eval-when-compile
+  (require 'subr-x))
+
 
 (defun editorconfig-core--get-handles (dir confname &optional result)
   "Get list of EditorConfig handlers for DIR from CONFNAME.

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -910,7 +910,7 @@ To disable EditorConfig in some buffers, modify
   "Find the closest .editorconfig file for current file."
   (interactive)
   (eval-and-compile (require 'editorconfig-core))
-  (when-let ((file (editorconfig-core-get-nearest-editorconfig
+  (when-let* ((file (editorconfig-core-get-nearest-editorconfig
                     default-directory)))
     (find-file file)))
 


### PR DESCRIPTION
- Load subr-x in editorconfig-core, too
- It seems for some cases when-let will be expanded differently and when-let* can be used to avoid this

Fixes #289 