### PR TITLE
Exclude some versions from test target

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,11 @@ jobs:
           # - os: windows-latest
           #   emacs_version: snapshot
           #   experimental: true
+        exclude:
+          - os: macos-latest
+            emacs_version: "26.3"
+          - os: macos-latest
+            emacs_version: "27.2"
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
nix-emacs-ci does not provide them any more.