### PR TITLE
feat: Include test on macos-11 below 28.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,34 +18,46 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs_version:
-          - "26.3"
-          - "27.2"
-          - "28.2"
-          - "29.3"
+        emacs-version:
+          - 28.2
+          - 29.3
         experimental: [false]
         include:
           - os: ubuntu-latest
-            emacs_version: snapshot
+            emacs-version: 26.3
+            experimental: false
+          - os: macos-11
+            emacs-version: 26.3
+            experimental: false
+          - os: windows-latest
+            emacs-version: 26.3
+            experimental: false
+          - os: ubuntu-latest
+            emacs-version: 27.2
+            experimental: false
+          - os: macos-11
+            emacs-version: 27.2
+            experimental: false
+          - os: windows-latest
+            emacs-version: 27.2
+            experimental: false
+          - os: ubuntu-latest
+            emacs-version: snapshot
             experimental: true
           - os: macos-latest
-            emacs_version: snapshot
+            emacs-version: snapshot
             experimental: true
+        exclude:
           # 2023/8/2 Recently this test always fails
           # so remove this until it works
-          # - os: windows-latest
-          #   emacs_version: snapshot
-          #   experimental: true
-        exclude:
-          - os: macos-latest
-            emacs_version: "26.3"
-          - os: macos-latest
-            emacs_version: "27.2"
-    continue-on-error: ${{ matrix.experimental }}
+          - os: windows-latest
+            emacs-version: snapshot
+            experimental: true
 
     steps:
       - name: Checkout
@@ -56,7 +68,7 @@ jobs:
       - name: Setup Emacs
         uses: jcs090218/setup-emacs@master
         with:
-          version: ${{ matrix.emacs_version }}
+          version: ${{ matrix.emacs-version }}
 
       - uses: emacs-eask/setup-eask@master
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,27 +24,27 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 28.2
-          - 29.3
+          - "28.2"
+          - "29.3"
         experimental: [false]
         include:
           - os: ubuntu-latest
-            emacs-version: 26.3
+            emacs-version: "26.3"
             experimental: false
           - os: macos-11
-            emacs-version: 26.3
+            emacs-version: "26.3"
             experimental: false
           - os: windows-latest
-            emacs-version: 26.3
+            emacs-version: "26.3"
             experimental: false
           - os: ubuntu-latest
-            emacs-version: 27.2
+            emacs-version: "27.2"
             experimental: false
           - os: macos-11
-            emacs-version: 27.2
+            emacs-version: "27.2"
             experimental: false
           - os: windows-latest
-            emacs-version: 27.2
+            emacs-version: "27.2"
             experimental: false
           - os: ubuntu-latest
             emacs-version: snapshot


### PR DESCRIPTION
Also change versions to unquoted, rename `emacs_version` to `emacs-version` and exclude windows-latest, snapshot in a nicer way