### PR TITLE
WIP: feat: Add templ support

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -300,6 +300,7 @@ This hook will be run even when there are no matching sections in
     (terra-mode terra-indent-level)
     (tcl-mode tcl-indent-level
               tcl-continued-indent-level)
+    (templ-ts-mode go-ts-mode-indent-offset)
     (toml-ts-mode toml-ts-mode-indent-offset)
     (typescript-mode typescript-indent-level)
     (typescript-ts-base-mode typescript-ts-mode-indent-offset)


### PR DESCRIPTION
Support [templ](https://templ.guide/) templates via [templ-ts-mode](https://github.com/danderson/templ-ts-mode).

[Indentation rules](https://github.com/danderson/templ-ts-mode/blob/1a98d65795da4cbb110516353963dab0cce35566/templ-ts-mode.el#L203-L232)

Unfortunately, this doesn't seem to work yet. `describe-editorconfig-properties` shows tab_width/indent_size set to the value expected from `.editorconfig`, but `go-ts-mode-indent-offset` remains at its default value, even if I call `editorconfig-apply` myself. Running `(setq-local go-ts-mode-indent-offset 2)` does change the indentation as expected.

Help appreciated :sweat_smile: