### PR TITLE
Fix 4 core-test failures

### DIFF
--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -222,8 +222,10 @@ If CONF is not found return nil."
                                     (substring line 0 idx))))
                     (value (editorconfig-core-handle--string-trim
                             (substring line (1+ idx)))))
-                (when (and (< (length key) 51)
-                           (< (length value) 256))
+                ;; `spec.editorconfig.org' says minimum 1024 and 4096 resp.
+                ;; FIXME: Why do we impose limits?
+                (when (and (< (length key) 2048)
+                           (< (length value) 8192))
                   (if pattern
                       (when (< (length pattern) 4097)
                         (setq props

--- a/editorconfig-core.el
+++ b/editorconfig-core.el
@@ -112,7 +112,7 @@ look like (KEY . VALUE)."
     (maphash (lambda (key value)
                (add-to-list 'result (cons (symbol-name key) value)))
              hash)
-    result))
+    (sort result (lambda (x y) (string< (car x) (car y))))))
 
 (defun editorconfig-core--hash-merge (into update)
   "Merge two hashes INTO and UPDATE.


### PR DESCRIPTION
This fixes the failures I see in

    155: semicolon_or_hash_in_property
    156: backslashed_semicolon_or_hash_in_property
    164: min_supported_key_length
    165: min_supported_value_length

* editorconfig-core-handle.el (editorconfig-core-handle--parse-file): Bump limits beyond the spec's minimum.

* editorconfig-core.el (editorconfig-core-get-properties): Sort the result so it doesn't depend on arbitrary hash-table implementation choices.