### PR TITLE
editorconfig.el: Hook elsewhere for the coding-system

### DIFF
--- a/ert-tests/editorconfig-tests.el
+++ b/ert-tests/editorconfig-tests.el
@@ -122,8 +122,12 @@
                 'iso-latin-1-unix)))
   (with-visit-file (concat editorconfig-ert-dir "utf-16be.txt")
     (set-buffer-file-coding-system 'undecided-unix)
-    (should (eq buffer-file-coding-system
-                'utf-16be-with-signature-unix)))
+    (unwind-protect
+        (progn
+          (save-buffer)
+          (should (eq buffer-file-coding-system
+                      'utf-16be-with-signature-unix)))
+      (delete-file (expand-file-name "utf-16be.txt" editorconfig-ert-dir))))
   (editorconfig-mode -1))
 
 


### PR DESCRIPTION
Until now, the file's coding system was set via an advice on `insert-file-contents`, which depends on being called from within the `find-file-noselect` advice.
While it mostly works, it doesn't account for all the cases (e.g. it fails to be used when doing `write-region`), is a bit cumbersome, and does not interact well with Emacs's other ways to specify a coding-system, such as `auto-coding-alist`.

This patch replaces it with an advice on `find-auto-coding`, so as to integrate better with the rest of Emacs's handling of files' coding systems.  An immediate benefit is that we don't need to special case jar and zip files any more because `auto-coding-alist` does it for us already (and for many more file types like tar, exe, ...).

* editorconfig.el (editorconfig-merge-coding-systems): Use `merge-coding-systems` only when merging is actually necessary. (editorconfig-set-coding-system-revert): Adjust accordingly. (editorconfig--filename-codingsystem-hash): Delete variable. (editorconfig--advice-insert-file-contents): Delete function. (editorconfig--advice-find-auto-coding): New function. (editorconfig--advice-find-file-noselect): Don't mess with coding systems any more.
(editorconfig--getting-coding-system): New var.
(editorconfig--get-coding-system): New function.
(editorconfig-mode): Advise `find-auto-coding` instead of `insert-file-contents`.
(editorconfig-version): Use `package-get-version` when available. (find-library-name, lm-version): Move their declaration to the place where we have a good reason to think they're defined. (editorconfig-exclude-regexps): Remove jar and zip patterns, not needed any more.