### PR TITLE
Finish support for insert_final_newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,7 @@ Current Emacs plugin coverage for EditorConfig's [properties][]:
 * `end_of_line`
 * `charset`
 * `trim_trailing_whitespace`
-* `insert_final_newline = true` is supported
-* ~~`insert_final_newline = false`~~ is not enforced
-  (as in trailing newlines actually being removed automagically),
-  we just buffer-locally override any preferences that would auto-add them
-  to files `.editorconfig` marks as trailing-newline-free
+* `insert_final_newline`
 * `max_line_length`
 * ~~`file_type_ext` (Experimental)~~ (See below)
 * ~~`file_type_emacs` (Experimental)~~ (See below)

--- a/editorconfig.el
+++ b/editorconfig.el
@@ -589,6 +589,17 @@ This function will revert buffer when the coding-system has been changed."
               (revert-buffer-with-coding-system coding-system)))
         (setq editorconfig--apply-coding-system-currently nil)))))
 
+(defun editorconfig--delete-final-newline ()
+  "Ensure the buffer does not end with a newline.
+Does nothing if the buffer is read-only."
+  (unless buffer-read-only
+    (save-excursion
+      (save-restriction
+        (widen)
+        (goto-char (point-max))
+        (while (looking-at-p "^$")
+          (delete-char -1))))))
+
 (defun editorconfig-set-trailing-nl (final-newline)
   "Set up requiring final newline by FINAL-NEWLINE.
 
@@ -598,12 +609,15 @@ to non-nil when FINAL-NEWLINE is true."
     ("true"
      ;; keep prefs around how/when the nl is added, if set - otherwise add on save
      (setq-local require-final-newline      (or require-final-newline t))
-     (setq-local mode-require-final-newline (or mode-require-final-newline t)))
+     (setq-local mode-require-final-newline (or mode-require-final-newline t))
+     (remove-hook 'before-save-hook
+                  #'editorconfig--delete-final-newline t))
+
     ("false"
-     ;; FIXME: Add functionality for actually REMOVING any trailing newlines here!
-     ;;        (rather than just making sure we don't automagically ADD a new one)
      (setq-local require-final-newline      nil)
-     (setq-local mode-require-final-newline nil))))
+     (setq-local mode-require-final-newline nil)
+     (add-hook 'before-save-hook
+               #'editorconfig--delete-final-newline nil t))))
 
 (defun editorconfig--delete-trailing-whitespace ()
   "Call `delete-trailing-whitespace' unless the buffer is read-only."


### PR DESCRIPTION
As noted in the documentation, `insert_final_newline = false` is expected to remove final newlines, but `editorconfig-mode` does not do that.

Use a similar pattern to `editorconfig-set-trailing-ws` by setting a buffer-local before-save hook to remove any final newline.

---

Fix #360.