### PR TITLE
Fix parsing section lines with trailing comments

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@ Hong Xu
 10sr
 Usami Kenta
 Izaak "Zaak" Beekman
+Ron Parker

--- a/editorconfig-core-handle.el
+++ b/editorconfig-core-handle.el
@@ -177,7 +177,7 @@ If CONF is not found return nil."
             nil)
 
            ;; Start of section
-           ((looking-at "\\[\\(.*\\)\\][ \t]*$")
+           ((looking-at "\\[\\(.*\\)\\][ \t]*\\(?:[#;].*\\)?$")
             (let ((newpattern (match-string 1)))
               (when pattern
                 (push (make-editorconfig-core-handle-section

--- a/ert-tests/editorconfig-core-handle-tests.el
+++ b/ert-tests/editorconfig-core-handle-tests.el
@@ -67,7 +67,11 @@
     (should (equal (editorconfig-core-handle-get-properties handle
                                                             (concat editorconfig--fixtures
                                                                     "a.js"))
-                   '((("key" . "value"))))))
+                   '((("key" . "value")))))
+    (should (equal (editorconfig-core-handle-get-properties handle
+                                                            (concat editorconfig--fixtures
+                                                                    "b.py"))
+                   '((("key2" . "value2"))))))
 
   ;; For checking various normal whitespace (line breaks, horizontal space, vertical space, etc.)
   (let* ((conf (concat default-directory

--- a/ert-tests/fixtures/handle2.ini
+++ b/ert-tests/fixtures/handle2.ini
@@ -1,3 +1,7 @@
 [a.js]
 
 key = value
+
+[b.py]  # Section comment
+
+key2 = value2


### PR DESCRIPTION
While working on [zsa/qmk_firmware](https://github.com/zsa/qmk_firmware), I ran into the following error related to parsing the listed section header line:

```
editorconfig-error: Error thrown from editorconfig lib: "Error from editorconfig-get-properties-function: (editorconfig-error \"Error from editorconfig-get-properties-function: (error \\\"Error while reading config file: /home/.../qmk_firmware/.editorconfig:14:
    [{*.yaml,*.yml}] # To match GitHub Actions formatting
\\\")\")"
```

While having a trailing comment on a section header line is unusual, to my knowledge, it is not forbidden. This change patches the relevant regexp using the optional comment pattern from the `cond` clause immediately above it.