### PR TITLE
Indent for js-json-mode

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -236,6 +236,7 @@ This hook will be run even when there are no matching sections in
                   java-ts-mode-indent-offset)
     (js-mode js-indent-level)
     (js-ts-mode js-indent-level)
+    (js-json-mode js-indent-level)
     (js-jsx-mode js-indent-level sgml-basic-offset)
     (js2-mode js2-basic-offset)
     (js2-jsx-mode js2-basic-offset sgml-basic-offset)


### PR DESCRIPTION
Emacs 30 uses `js-json-mode` for JSON files which [no longer derives from][1] `js-mode`.

[1]: https://cgit.git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30#n1521