### PR TITLE
editorconfig-fnmatch: improve ** globs

### DIFF
--- a/editorconfig-fnmatch.el
+++ b/editorconfig-fnmatch.el
@@ -166,7 +166,9 @@ translation is found for PATTERN."
             (setq pos index)
             (if (and (< pos length)
                      (= (aref pattern pos) ?*))
-                ".*"
+                (progn
+                  (setq index (1+ index))
+                  ".*")
               "[^/]*"))
 
            (?? "[^/]")


### PR DESCRIPTION
This should make the generated regexes a little bit neater.