### PR TITLE
Improve Swift indentation support

### DIFF
--- a/editorconfig.el
+++ b/editorconfig.el
@@ -260,7 +260,9 @@ This hook will be run even when there are no matching sections in
     (scala-mode scala-indent:step)
     (scss-mode css-indent-offset)
     (sh-mode sh-basic-offset sh-indentation)
-    (swift-mode swift-mode:basic-offset)
+    (swift-mode swift-mode:basic-offset
+                swift-mode:multiline-statement-offset
+                swift-mode:parenthesized-expression-offset)
     (tcl-mode tcl-indent-level
               tcl-continued-indent-level)
     (templ-ts-mode go-ts-mode-indent-offset js-indent-level)


### PR DESCRIPTION
## Summary

This updates Swift indentation support so that `indent_size` is applied to all relevant `swift-mode` indentation offsets:

- `swift-mode:basic-offset`
- `swift-mode:multiline-statement-offset`
- `swift-mode:parenthesized-expression-offset`

Previously, `editorconfig-emacs` only applied `indent_size` to `swift-mode:basic-offset`.

## Background

This follows the discussion in swift-emacs/swift-mode#202.

Historically `swift-mode` has three separate indentation settings for Swift code: block indentation, multiline statement indentation, and parenthesized expression indentation. They are all customizable via `defcustom` in `swift-mode`:

https://github.com/swift-emacs/swift-mode/blob/5782bb9ab0773b5c6abddc23a14b82e5356cc2db/swift-mode-indent.el#L36-L52

In that discussion, we agreed that `swift-mode` should move towards using the same indentation value for these offsets by default. This PR applies the same idea on the `editorconfig-emacs` side: when a project provides `indent_size`, it should be applied to all three Swift indentation settings instead of only `swift-mode:basic-offset`.

This makes `editorconfig-emacs` handle all indentation settings exposed by `swift-mode`, so that a project-level `indent_size` can control Swift indentation consistently.